### PR TITLE
updated subscribe box styles w/signoff

### DIFF
--- a/_includes/subscribe.html
+++ b/_includes/subscribe.html
@@ -1,6 +1,6 @@
 
 
-<div style="border: 1px black dashed; padding-top:2rem;margin-top:2rem;">
+<div style="border: 1px black dashed; padding-top:2rem;margin-top:2rem;box-shadow: 0 10px 30px rgba(0,0,0,.2);">
   <a id="subscribe" class="subscribe-a"></a>
   <!-- Begin MailChimp Signup Form -->
   <link
@@ -8,7 +8,7 @@
     rel="stylesheet"
     type="text/css"
   />
-  <p style="color:black; font-style:italic; text-align:center; font-size: 1rem;">Stay meshy and subscribe.</p>
+  <p style="font-style:italic; text-align:center; font-size: 1rem;text-transform: capitalize;font-weight: bold;color: #141414;">Stay meshy and subscribe.</p>
   <!-- <div id="mc_embed_signup"> -->
   <div id="mc_embed_signup">
     <form
@@ -30,7 +30,7 @@
             name="FNAME"
             class="email"
             id="mce-FNAME"
-            style="width: 49%"
+            style="width: 49%;padding: 1.2em .5em;background-color: #fafafa;"
           />
           <input
             type="text"
@@ -39,7 +39,7 @@
             name="LNAME"
             class="email"
             id="mce-LNAME"
-            style="width: 49%"
+            style="width: 49%;padding: 1.2em .5em;background-color: #fafafa;"
           />
         </div>
         <div id="mce-responses" class="clear subscribe-inputbox">
@@ -66,7 +66,7 @@
             id="mce-EMAIL"
             placeholder="Email Address"
             required
-            style="white-space: nowrap; display: inline-block; width: 100%"
+            style="white-space: nowrap; display: inline-block; width: 100%;padding: 1.2em .5em;background-color: #fafafa;"
           />
           <!-- <span class="asterisk" style="white-space: nowrap;">*</span> -->
         </div>
@@ -96,7 +96,7 @@
               name="subscribe"
               id="mc-embedded-subscribe"
               style="  padding: .8rem .5rem;
-              background: rgba(100, 120, 129, 1);"
+              background: rgba(100, 120, 129, 1);font-weight: bold;letter-spacing: .5px;"
             />
           </h4>
         </div>
@@ -108,7 +108,7 @@
   <div id="mc_other_mailinglist">
     <h3 style="line-height: normal; margin: 0;">Mailing lists</h3>
     <p style="color: #CCC; font-size: 1rem;font-style:italic;">Engage in the Meshery project.  Join any of our mailing lists.</p>
-    <div id="mc_mailinglist_group">
+    <div id="mc_mailinglist_group" style="width: 100%;">
       <a href="https://groups.google.com/a/meshery.io/g/dev-group" class="mc-maillists_button">Dev</a>
       <a href="https://groups.google.com/a/meshery.io/g/user-group" class="mc-maillists_button">User</a>
     </div>


### PR DESCRIPTION
Signed-off-by: Nikhil <nikhilsharmamusic2000@gmail.com>

**Description**
## Updated Subscribe Box Styles
**Current State**
![Before_Main](https://user-images.githubusercontent.com/58226527/119815366-13a31d80-bf09-11eb-8b84-66a8c6ad5590.png)

**After Changes**
- added box-shadow
- increased buttons width
- updated input box color
- transform font of heading
- font-weight to "Subscribe" text

![After_Main](https://user-images.githubusercontent.com/58226527/119815691-71d00080-bf09-11eb-901c-e86f2f5d83dd.png)

## Fixed Responsive Issue
**Current State**
The buttons are not taking full width in smaller devices leaving a margin in the right. 
![Before_Responsive](https://user-images.githubusercontent.com/58226527/119816131-f6bb1a00-bf09-11eb-9cb0-a2f4ceaa52fb.png)


**After Changes**
The buttons are using full width ( which is the default convention )
![After_Responsive](https://user-images.githubusercontent.com/58226527/119816119-f1f66600-bf09-11eb-8015-cfc66ce2b93a.png)


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
