### PR TITLE
fix: Get Started button not linked to specific area of the Meshery docs

### DIFF
--- a/collections/_pages/features.html
+++ b/collections/_pages/features.html
@@ -2,7 +2,7 @@
 layout: page
 permalink: /features
 title: Features
-heading: Meshery is the service mesh management plane
+heading: Meshery is <i>the</i> service mesh management plane
 description: Adopt and operate any service mesh with confidence using Meshery's management features.
 features_table:
   - name: Lifecycle

--- a/collections/_pages/features.html
+++ b/collections/_pages/features.html
@@ -2,7 +2,7 @@
 layout: page
 permalink: /features
 title: Features
-heading: Meshery is <i>the</i> service mesh management plane
+heading: Meshery is the service mesh management plane
 description: Adopt and operate any service mesh with confidence using Meshery's management features.
 features_table:
   - name: Lifecycle
@@ -25,7 +25,7 @@ features_table:
       - text:
         highlight:
     call_to_action:
-      link: /#getting-started
+      link: https://docs.meshery.io/functionality/lifecycle-management#lifecycle-management
       text: Get started
   - name: Configuration
     color: "#00B39F"
@@ -50,7 +50,7 @@ features_table:
       - text:
         highlight:
     call_to_action:
-      link: /#getting-started
+      link: https://docs.meshery.io/functionality/lifecycle-management#configuration-management
       text: Get started
   - name: Performance
     color: "#00B39F"
@@ -71,7 +71,7 @@ features_table:
         highlight: false
         featureli: true
     call_to_action:
-      link: /#getting-started
+      link: https://docs.meshery.io/functionality/performance-management
       text: Get started
   - name: Wasm Filters
     color: "#00B39F"
@@ -86,7 +86,7 @@ features_table:
         highlight: false
         featureli: true
     call_to_action:
-      link: /#getting-started
+      link: https://docs.meshery.io/functionality/filter-management#q-what-is-wasm-
       text: Get started
 <!-- faq:
   - question: What types of payment do you accept?

--- a/collections/_pages/features.html
+++ b/collections/_pages/features.html
@@ -86,7 +86,7 @@ features_table:
         highlight: false
         featureli: true
     call_to_action:
-      link: https://docs.meshery.io/functionality/filter-management#q-what-is-wasm-
+      link: https://docs.meshery.io/functionality/filter-management
       text: Get started
 <!-- faq:
   - question: What types of payment do you accept?


### PR DESCRIPTION
**Description**
Get Started buttons now link to a specific area of its docs

This PR fixes #504 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
