### PR TITLE
Para and Image are now of same size and added hoverable buttons in th…

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,9 @@ image: images/logos/meshery-logo-light-text-pad.png
 				<span  style="position: relative; top:-30px;">
 				<h2>Use the <strong>Service Mesh Performance</strong> standard</h2>
 				<p>Weigh the value of your service mesh features in-context of it's overhead.
-					<div align="center" class="button adopter-button">
-						<a href="https://smp-spec.io">See Service Mesh Performance(SMP)</a>
+				
+					<div align="center" class="button adopter-button" style="margin-top: 2rem;">
+						<a href="https://smp-spec.io">See Service Mesh Performance (SMP)</a>
 					</div>
 				</p>
 			</span>
@@ -96,7 +97,8 @@ image: images/logos/meshery-logo-light-text-pad.png
 				<h2>What are <strong>configuration best practices</strong> and patterns?</h2>
 				<p> Assess your service mesh configuration against deployment and
 					operational best practices with Meshery's configuration validator.
-				<div align="center" class="button adopter-button">
+					<br>
+				<div align="center" class="button adopter-button" style="margin-top: 3rem;">
 					<a href="https://docs.meshery.io">See the service mesh patterns</a>
 				</div>
 				</p>
@@ -124,7 +126,8 @@ image: images/logos/meshery-logo-light-text-pad.png
 
 				<h2>Is your service mesh <strong>SMI compliant</strong>?</h2>
 				<p> Validate your service mesh's conformance to Service Mesh Interface (SMI) specifications.
-				<div align="center" class="button adopter-button">
+					<br>
+				<div align="center" class="button adopter-button" style="margin-top: 3rem;">
 					<a href="/service-mesh-interface">See the testing SMI conformance</a>
 				</div>
 				</p>
@@ -152,7 +155,8 @@ image: images/logos/meshery-logo-light-text-pad.png
 				<!-- </a> -->
 				<h2>Manage data plane intelligence with <strong>WebAssembly filters</strong></h2>
 				<p>Dynamically load and manage your own WebAssembly filters in Envoy-based service meshes.
-				<div align="center" class="button adopter-button">
+					<br>
+				<div align="center" class="button adopter-button" style="margin-top: 2rem;">
 				<a href="https://github.com/layer5io/image-hub" >See Image Hub</a>
 				</div>
 				</p>
@@ -179,8 +183,9 @@ image: images/logos/meshery-logo-light-text-pad.png
 				<h2>Which service mesh should I use and how do I <strong>get started</strong>?</h2>
 				<p>Learn about the functionality of different service meshes
 					and visually manipulate mesh configuration.
-				<div align="center">
-					See the <a href="https://docs.meshery.io">Meshery documentation</a>.
+					<br>
+				<div align="center" class="button adopter-button" style="margin-top: 3rem;">
+					<a href="https://docs.meshery.io">See the Meshery documentation</a>
 				</div>
 				</p>
 			</div>

--- a/index.html
+++ b/index.html
@@ -70,13 +70,14 @@ image: images/logos/meshery-logo-light-text-pad.png
 				<span  style="position: relative; top:-30px;">
 				<h2>Use the <strong>Service Mesh Performance</strong> standard</h2>
 				<p>Weigh the value of your service mesh features in-context of it's overhead.
-					<div align="center">
-						See <a href="https://smp-spec.io">Service Mesh Performance</a> (SMP).
+					<div align="center" class="button adopter-button">
+						<a href="https://smp-spec.io">See Service Mesh Performance(SMP)</a>
 					</div>
 				</p>
 			</span>
 			</div>
-			<div class="image flex" style="flex-basis:30%;">
+			<!--removed style="flex-basis:30%; so that image and text can occupy same width-->
+			<div class="image flex">
 				<a href="images/screens/service mesh performance example.gif" data-fancybox="images"
 					data-caption="Service Mesh Performance Specification">
 					<img src="{{ site.baseurl }}/images/screens/service mesh performance example.gif"
@@ -95,12 +96,12 @@ image: images/logos/meshery-logo-light-text-pad.png
 				<h2>What are <strong>configuration best practices</strong> and patterns?</h2>
 				<p> Assess your service mesh configuration against deployment and
 					operational best practices with Meshery's configuration validator.
-				<div align="center">
-					See the <a href="https://docs.meshery.io">service mesh patterns</a>
+				<div align="center" class="button adopter-button">
+					<a href="https://docs.meshery.io">See the service mesh patterns</a>
 				</div>
 				</p>
 			</div>
-			<div class="image" style="flex-basis:20%;">
+			<div class="image" >
 				<a href="images/screens/meshery-configuration-management.png" data-fancybox="images"
 					data-caption="Service Mesh configuration Comparison">
 					<img src="{{ site.baseurl }}/images/screens/meshery-configuration-management.png"
@@ -123,12 +124,12 @@ image: images/logos/meshery-logo-light-text-pad.png
 
 				<h2>Is your service mesh <strong>SMI compliant</strong>?</h2>
 				<p> Validate your service mesh's conformance to Service Mesh Interface (SMI) specifications.
-				<div align="center">
-					See the <a href="/service-mesh-interface">testing SMI conformance</a>
+				<div align="center" class="button adopter-button">
+					<a href="/service-mesh-interface">See the testing SMI conformance</a>
 				</div>
 				</p>
 			</div>
-			<div class="image" style="flex-basis:25%;">
+			<div class="image" >
 				<a href="images/screens/SMI-Conformance-in-Meshery.png" data-fancybox="images"
 					data-caption="Service Mesh configuration Comparison">
 					<img src="{{ site.baseurl }}/images/screens/SMI-Conformance-in-Meshery.png"
@@ -151,12 +152,12 @@ image: images/logos/meshery-logo-light-text-pad.png
 				<!-- </a> -->
 				<h2>Manage data plane intelligence with <strong>WebAssembly filters</strong></h2>
 				<p>Dynamically load and manage your own WebAssembly filters in Envoy-based service meshes.
-				<div align="center">
-					See <a href="https://github.com/layer5io/image-hub">Image Hub</a>.
+				<div align="center" class="button adopter-button">
+				<a href="https://github.com/layer5io/image-hub" >See Image Hub</a>
 				</div>
 				</p>
 			</div>
-			<div class="image flex" style="flex-basis:20%;">
+			<div class="image flex">
 				<a href="{{ site.baseurl }}/images/meshery-wasm.png" data-fancybox="images"
 					data-caption="Webassembly based Envoy Filters">
 					<img src="{{ site.baseurl }}/images/meshery-wasm.png"

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@ image: images/logos/meshery-logo-light-text-pad.png
 					operational best practices with Meshery's configuration validator.
 					<br>
 				<div align="center" class="button adopter-button" style="margin-top: 3rem;">
-					<a href="https://docs.meshery.io">See the service mesh patterns</a>
+					<a href="https://docs.meshery.io/functionality/pattern-management">See the service mesh patterns</a>
 				</div>
 				</p>
 			</div>


### PR DESCRIPTION
…e links within the paragraphs w/signoff

Signed-off-by: AnshumanDhiman <67755381+AnshumanDhiman@users.noreply.github.com>

As discussed with lee I had removed the marquee and the color of slack icon is also set to default.
The paragraph and the supporting image will now occupy same space and instead of href links added hoverable buttons to them

This PR fixes #532 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
