### PR TITLE
Change install guide to go Kubernetes first

### DIFF
--- a/_includes/getting-started.html
+++ b/_includes/getting-started.html
@@ -84,6 +84,19 @@
       <div id="bash_code" class="toggle hideDiv">
         <div class="innerDiv">
           <h3>Bash using Mac or Linux</h3>
+
+          <p>Install on Kubernetes</p>
+  
+              <div id="start-k8s" class="highlight-code">
+                  <p class="code-box"><code style="position: absolute;">  $ curl -L https://git.io/meshery | PLATFORM=kubernetes bash - </code></p>
+                  <!-- copy to clipboard -->
+                  <a class="btn tooltip" data-clipboard-target="#start-k8s" data-clipboard-text="curl -L https://git.io/meshery | PLATFORM=kubernetes bash -"
+                    onmouseout="resetCopyText(this)" style="position:absolute; top: 0.10rem; right: 0.5rem; font-size: 22px;">
+                    <i class="far fa-copy"></i>
+                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 3rem; left: -20px;">Copy to clipboard</span>
+                  </a>
+                </div>
+                
             <p>Install on Docker</p>
 
             <div id="start-docker" class="highlight-code">
@@ -95,19 +108,6 @@
                   <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 3rem; left: -20px;">Copy to clipboard</span>
                 </a>
               </div>
-              
-              <p>Install on Kubernetes</p>
-  
-              <div id="start-k8s" class="highlight-code">
-                  <p class="code-box"><code style="position: absolute;">  $ curl -L https://git.io/meshery | PLATFORM=kubernetes bash - </code></p>
-                  <!-- copy to clipboard -->
-                  <a class="btn tooltip" data-clipboard-target="#start-k8s" data-clipboard-text="curl -L https://git.io/meshery | PLATFORM=kubernetes bash -"
-                    onmouseout="resetCopyText(this)" style="position:absolute; top: 0.10rem; right: 0.5rem; font-size: 22px;">
-                    <i class="far fa-copy"></i>
-                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 3rem; left: -20px;">Copy to clipboard</span>
-                  </a>
-                </div>
-
 
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendupottekkat@gmail.com>

**Description**

This PR is related to switching the default platform to deploy Meshery to Kubernetes. See https://github.com/meshery/meshery/issues/4233

Changes the first install guide to say about Kubernetes installation instead of Docker.

- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
