### PR TITLE
[UI]Fixed gap between "Overview" and "Getting Started" section

### DIFF
--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -342,7 +342,6 @@
 
 .overview-section {
   padding-top: 10px;
-  margin-bottom: 4rem;
   color: #fff;
   align-items: center;
   background-color: #222;


### PR DESCRIPTION
Signed-off-by: Ghulam Yazdani <ghulamyazdani12@gmail.com>

**Description**
Removed the useless gap between "Overview" and "Getting Started" section
**After Changes**
![meshery2](https://user-images.githubusercontent.com/55938346/137447949-ba3185fd-85e8-4ebe-9ebc-46cd9def0fa6.png)

This PR fixes #585

**Notes for Reviewers**
Ready for the review!

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
