### PR TITLE
fixed: LFX box size dissimilarity

### DIFF
--- a/_includes/programs.html
+++ b/_includes/programs.html
@@ -45,7 +45,7 @@
 
   .minicard-img {
     width: 10%;
-    height: inherit;
+    height: 30px;
     vertical-align: middle;
     position: relative;
     z-index: -1;


### PR DESCRIPTION
Signed-off-by: amino19 <anshumaankrprasad76@gmail.com>

**Description**
In the Programs' section (bottom), the LFX box height increased to `30 px`, seems as similar to other boxes such as GSOC, GSOD & CNCF.

**Web preview:-**
![image](https://user-images.githubusercontent.com/75872316/139855620-dcc703c7-a998-47ed-94d9-781fbff0c97f.png)

**Mobile preview:-**
![image](https://user-images.githubusercontent.com/75872316/139855843-100fd8df-6ef3-4d10-9471-778346041d0a.png)

This PR fixes #607 

**Notes for Reviewers**
Ready to review, hence it touches the goals!


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
