### PR TITLE
fix: video stop on modal close issue fixed w/signoff

### DIFF
--- a/assets/js/talks-presentations.js
+++ b/assets/js/talks-presentations.js
@@ -40,12 +40,18 @@ modal[n].addEventListener('click',function(){
     modal[n].style.visiblity = "hidden";
     modal[n].style.opacity = "0";
     modal[n].style.pointerEvents= "none";
+    let iframeTEST = modal[n].childNodes[1].childNodes[5].childNodes[1];
+    let src = iframeTEST.src;
+    iframeTEST.src = src;
 
 });
 btnClose[n].addEventListener('click',function(){
     modal[n].style.visiblity = "hidden";
     modal[n].style.opacity = "0";
     modal[n].style.pointerEvents= "none";
+    let iframeTEST = modal[n].childNodes[1].childNodes[5].childNodes[1];
+    let src = iframeTEST.src;
+    iframeTEST.src = src;
 });
 
 btnOpen.addEventListener('click',function(){

--- a/assets/js/talks-presentations.js
+++ b/assets/js/talks-presentations.js
@@ -9,6 +9,9 @@ for(let i=0;i<n;i++){
         modal[i].style.visiblity = "hidden";
         modal[i].style.opacity = "0";
         modal[i].style.pointerEvents= "none";
+        let iframeTEST = modal[i].childNodes[1].childNodes[5].childNodes[1];
+        let src = iframeTEST.src;
+        iframeTEST.src = src;
 
     });
 
@@ -16,6 +19,9 @@ for(let i=0;i<n;i++){
         modal[i].style.visiblity = "hidden";
         modal[i].style.opacity = "0";
         modal[i].style.pointerEvents= "none";
+        let iframeTEST = modal[i].childNodes[1].childNodes[5].childNodes[1];
+        let src = iframeTEST.src;
+        iframeTEST.src = src;
     });
 
     recordingLink[i].addEventListener('click',function(){


### PR DESCRIPTION
Signed-off-by: RajGM <rajgmsocial19@gmail.com>

**Description**
Video Stops on when modal is closed either through the close button or by clicking elsewhere on the page.

This PR fixes #


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
