### PR TITLE
changed the order of catalog patterns

### DIFF
--- a/catalog/index.html
+++ b/catalog/index.html
@@ -30,19 +30,40 @@ permalink: /catalog
 </style>
 
 {% assign catalog = site.catalog | sort: 'patternId' %}
-{% for pattern in catalog %}
-  <div class="row">
-    <div class="column">
-        {% if pattern.Status == "ComingSoon" %}
-        {% include coming-soon.html %}
-        {% elsif pattern.patternInfo %}
-        {% include card.html %}
-        {% else %}
-        {%include wasm-card.html %}  
+<div class = "row">
+  {% for pattern in catalog %}
+      <div class="column">
+        {% if pattern.patternInfo and pattern.Status != "ComingSoon" %}
+          {% include card.html %}
+        {% include modal.html %}
         {% endif %}
       </div>
-        {% include modal.html %}
-        {% endfor %}    
+      
+      {% endfor %}
+    
+  
+
+  {% for pattern in catalog %}
+
+      <div class="column">
+        {% if pattern.filterInfo and pattern.Status != "ComingSoon" %}
+          {% include wasm-card.html %}
+          {% include modal.html %}
+        {% endif %}
+      </div>
+      
+    {% endfor %}
+    
+  
+  {% for pattern in catalog %}
+
+      <div class="column">
+        {% if pattern.patternInfo and pattern.Status == "ComingSoon" %}
+          {% include coming-soon.html %}
+        {% endif %}
+      </div>
+    {% endfor %}
+    
   </div>
 
 


### PR DESCRIPTION
Signed-off-by: asubedy <frexpe@pm.me>

**Description**
This was the only way I could think of showing the meshery patterns at first without changing WASM filters `patternID`

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
