### PR TITLE
changed link to readme

### DIFF
--- a/_includes/help-modal.html
+++ b/_includes/help-modal.html
@@ -70,7 +70,7 @@
 }
 </style>
 <p class="catalog-subtext">
-Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import any catalog item</span> into Meshery. Have a design pattern to share? <a style ="color: #00D3AF; text-decoration: none;" href="https://github.com/meshery/meshery.io/issues/new?assignees=&labels=area%2Fcatalog&template=add-new-pattern.md&title=%5BCatalog%5D">Add yours to the catalog.</a></p>
+Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import any catalog item</span> into Meshery. Have a design pattern to share? <a style ="color: #00D3AF; text-decoration: none;" href="https://github.com/meshery/meshery.io/blob/master/README.md#add-your-patterns-to-the-catalog">Add yours to the catalog.</a></p>
 <div id="myModal" class="help-modal">
     <div class="help-modal-content">
        


### PR DESCRIPTION
Signed-off-by: Aditya Chatterjee <speak2adi@gmail.com>

**Description**
@leecalcote I added the instructions to the readme instead of putting it in a modal because we'd need to make a new modal again with our current approach. Instead, we should work on refactoring the modal to make it reusable (something that you've said a no. of times 😅). So this is a temp. fix until we have one of those. 
This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
