### PR TITLE
navbar dropdown mobile view width fix

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -86,6 +86,10 @@ header {
             display: block;
             width: auto;
         }
+
+        @media (max-width: 568px){
+            position: absolute;
+        }
     }
 }
 

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -89,6 +89,7 @@ header {
 
         @media (max-width: 568px){
             position: absolute;
+            z-index: 2;
         }
     }
 }


### PR DESCRIPTION
**Description**

This PR fixes #812 

<img src="https://user-images.githubusercontent.com/78253058/186101654-7b08f589-3e74-4188-a9c1-2a89e8e134e3.png" height="400">

**Notes for Reviewers**


Now navbar dropdown will take full width below 568px.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
