### PR TITLE
Fix: Use token in checkout action for update_catalog

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Set env
         run : |
           echo "MESHERY_CLOUD_BASE_URL=https://meshery.layer5.io" >> $GITHUB_ENV
@@ -148,4 +150,3 @@ jobs:
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit_options: '--signoff'
           commit_message: '[Catalog] Update Catalog items'
-          token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Ruturaj Mohite <mohite.ruturaj15@gmail.com>

**Description**
Use the PAT in the checkout action instead of the commit action. The commit action does not support a token parameter.
refer: https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
