### PR TITLE
Spelling fix #971: Fixed "Compatibility" typo in mobile catalog filter dropdown

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/meshery.io.iml
+++ b/.idea/meshery.io.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/meshery.io.iml" filepath="$PROJECT_DIR$/.idea/meshery.io.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/_includes/patterns-filter.html
+++ b/_includes/patterns-filter.html
@@ -78,7 +78,7 @@
     </button>
     <div id="myDropdown" class="dropdown-content">
       <a id="category-li">Categories</a>
-      <a id="compatibility-li">Compatibilty</a>
+      <a id="compatibility-li">Compatibility</a>
       <a id="technology-li">Technology</a>
     </div>
   </div>


### PR DESCRIPTION
Signed-off-by: Saad Kadhi <thelittlebigartist@gmail.com>

**Description**

This PR fixes the spelling typo #971 found in the catalog filter dropdown menu which had the incorrect spelling "Compatibilty". This fix solves the issue by renaming the text to "Compatibility".

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
