### PR TITLE
text visibility issue in dark mode resolved

### DIFF
--- a/_includes/type.html
+++ b/_includes/type.html
@@ -10,7 +10,7 @@
 		</span>
     </div>
 	{% endfor %}
-	<strong>Updated at: </strong> <em><span class="post-date">{{ include.post.date | date: "%B %d, %Y" }}</span></em>
+	<strong class="post-update">Updated at: </strong> <em><span class="post-date post-update">{{ include.post.date | date: "%B %d, %Y" }}</span></em>
 	<br>
-	<strong>Version: </strong> <em>1.0</em>
+	<strong class="post-update">Version: </strong> <em class="post-update">1.0</em>
 </p>

--- a/_sass/catalog.scss
+++ b/_sass/catalog.scss
@@ -456,7 +456,7 @@ input[type="checkbox"] {
   }
 }
 .modal-pattern-name {
-  color: #333;
+  color: var(--color-secondary-dark);
   text-align: center;
   font-weight: 800;
   font-size: 12px;
@@ -510,6 +510,7 @@ input[type="checkbox"] {
   padding-bottom: 0px;
 }
 .modal-pattern-id {
+  color: var(--color-secondary-dark);
   position: absolute;
 	bottom: 0;
 	font-size: 8px;
@@ -558,6 +559,10 @@ open-modal-btn {
 }
 .tooltip-modal:hover {
   text-decoration: none;
+}
+
+.post-update{
+  color: var(--color-secondary-dark);
 }
 
 .pattern-filter-image {


### PR DESCRIPTION
**Description**

This PR fixes #1045 
The text was hidden or not visible in dark mode but now it is resolved. Text is visible in both mode
![image](https://user-images.githubusercontent.com/90546692/221964578-f4da685f-dd97-407a-aef7-2cf456057c94.png)


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
