### PR TITLE
configuration of help-modal and import instruction on each catelog page

### DIFF
--- a/_includes/help-modal.html
+++ b/_includes/help-modal.html
@@ -46,6 +46,10 @@
   border-top: none;
 }
 
+h3{
+  text-align: center;
+}
+
 /* Modal Content/Box */
 .help-modal-content {
   background-color: #fefefe;

--- a/_includes/help-modal.html
+++ b/_includes/help-modal.html
@@ -73,16 +73,16 @@
   position: absolute;
   top:1.8rem; 
   right: 0.5rem; 
-  font-size: 22px;
+  font-size: 1.37rem;
   margin-right: 10px;
 }
 
 @media only screen and (max-width: 768px) {
   .tooltip {
-    font-size: 14px; /* Decrease the font size */
+    font-size: 0.875rem; /* Decrease the font size */
   }
   .tooltip i {
-    font-size: 18px;
+    font-size: 1.125rem;
     position: relative; /* Set the position to relative */
     top: -2rem;
   }

--- a/_includes/help-modal.html
+++ b/_includes/help-modal.html
@@ -68,6 +68,25 @@
   text-decoration: none;
   cursor: pointer;
 }
+
+.tooltip{
+  position: absolute;
+  top:1.8rem; 
+  right: 0.5rem; 
+  font-size: 22px;
+  margin-right: 10px;
+}
+
+@media only screen and (max-width: 768px) {
+  .tooltip {
+    font-size: 14px; /* Decrease the font size */
+  }
+  .tooltip i {
+    font-size: 18px;
+    position: relative; /* Set the position to relative */
+    top: -2rem;
+  }
+}
 </style>
 <p class="catalog-subtext">
 Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import any catalog item</span> into Meshery. Have a design pattern to share? <a style ="color: #00D3AF; text-decoration: none;" href="https://github.com/meshery/meshery.io/blob/master/README.md#add-your-patterns-to-the-catalog">Add yours to the catalog.</a></p>
@@ -75,7 +94,7 @@ Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import any cata
     <div class="help-modal-content">
        
         <div class="tab">
-            <span class="closed" style=" padding: 4px 4px">&times;</span>
+            <span class="closed" style=" padding: 4px 15px">&times;</span>
             <button class="tablinks active" onclick="openTab(event, 'MesheryUI')">Meshery UI</button>
             <button class="tablinks" onclick="openTab(event, 'MesheryCLI')">Meshery CLI</button>
           </div>
@@ -100,39 +119,39 @@ Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import any cata
           <div id="MesheryCLI" class="tabcontent" style="display: none;">
             <h3>Meshery CLI</h3>
             <p>1. Apply a pattern file. </p>
-            <div id="start-pattern" class="highlight-code">
-                <p class="code-box" style="height: 40px; line-height: 15px; color: white"><code style="position: absolute;">
+            <div id="start-pattern" class="highlight-code" style="padding: 5px;">
+                <p class="code-box" style="height: 20px; line-height: 1px; color: white; white-space: nowrap; margin-left: 10px;"><code style="position: absolute;">
                     mesheryctl pattern apply -f [file | URL]
                  </code></p>
                   <!-- copy to clipboard -->
-                  <a class="btn tooltip" style="position: absolute; top:0.10rem; right: 0.5rem; font-size: 22px;" data-clipboard-target="#start-brew"
-                    data-clipboard-text="mesheryctl pattern apply -f [file | URL]" onmouseout="resetCopyText(this)">
+                  <a class="btn tooltip" data-clipboard-target="#start-brew"
+                    data-clipboard-text="mesheryctl pattern apply -f [file | URL]">
                     <i class="far fa-copy"></i>
-                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 2rem; left: -80px;">Copy to clipboard</span>
+                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 1.2rem; left: -80px;">Copy to clipboard</span>
                   </a>
               </div>
             <p>2. Onboard an application.</p>
-            <div id="start-app" class="highlight-code">
-                <p class="code-box" style="height: 40px; line-height: 15px; color: white"><code style="position: absolute;">
+            <div id="start-app" class="highlight-code" style="padding: 5px;">
+                <p class="code-box" style="height: 20px; line-height: 1px; color: white; white-space: nowrap; margin-left: 10px;"><code style="position: absolute;">
                     mesheryctl app onboard -f [file-path]
                  </code></p>
                   <!-- copy to clipboard -->
-                  <a class="btn tooltip" style="position: absolute; top:0.10rem; right: 0.5rem; font-size: 22px;" data-clipboard-target="#start-brew"
-                    data-clipboard-text="mesheryctl app onboard -f [file-path]" onmouseout="resetCopyText(this)">
+                  <a class="btn tooltip"  data-clipboard-target="#start-brew"
+                    data-clipboard-text="mesheryctl app onboard -f [file-path]">
                     <i class="far fa-copy"></i>
-                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 2rem; left: -80px;">Copy to clipboard</span>
+                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 1.2rem; left: -80px;">Copy to clipboard</span>
                   </a>
               </div>
             <p>3. Apply a WASM filter file.</p>
-            <div id="start-pattern" class="highlight-code">
-                <p class="code-box" style="height: 40px; line-height: 15px; color: white"><code style="position: absolute;">
+            <div id="start-pattern" class="highlight-code" style="padding: 5px;">
+                <p class="code-box" style="height: 20px; line-height: 1px; color: white; white-space: nowrap; margin-left: 10px ;"><code style="position: absolute;">
                     mesheryctl exp filter apply --file [GitHub Link]
                  </code></p>
                   <!-- copy to clipboard -->
-                  <a class="btn tooltip" style="position: absolute; top:0.10rem; right: 0.5rem; font-size: 22px;" data-clipboard-target="#start-brew"
-                    data-clipboard-text="mesheryctl exp filter apply --file [GitHub Link]" onmouseout="resetCopyText(this)">
+                  <a class="btn tooltip"  data-clipboard-target="#start-brew"
+                    data-clipboard-text="mesheryctl exp filter apply --file [GitHub Link]">
                     <i class="far fa-copy"></i>
-                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 2rem; left: -80px;">Copy to clipboard</span>
+                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 1.2rem; left: -80px;">Copy to clipboard</span>
                   </a>
               </div>
           </div>

--- a/_includes/partials/individual-component.html
+++ b/_includes/partials/individual-component.html
@@ -122,7 +122,7 @@ margin-right: 10px;
       {% include partials/compatibility.html%}
       {% include copy-and-download.html %}
       <br/>
-      <p class="catalog-subtext" style="text-align: inherit;"><span style="color: #fff; font-weight: bold;">Note: </span>Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import this design item</span> into Meshery <a style ="color: #00D3AF; text-decoration: none;"></a>"</p>
+      <p class="catalog-subtext" style="text-align: inherit;"><span style="font-weight: bold;">Note:</span> </span>Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import this design item</span> into Meshery <a style ="color: #00D3AF; text-decoration: none;"></a></p>
     </div>
     
   </div>

--- a/_includes/partials/individual-component.html
+++ b/_includes/partials/individual-component.html
@@ -1,3 +1,94 @@
+<style>
+  .help-modal {
+display: none; /* Hidden by default */
+position: fixed; /* Stay in place */
+z-index: 100; /* Sit on top */
+left: 0;
+top: 0;
+width: 100%; /* Full width */
+height: 100%; /* Full height */
+overflow: auto; /* Enable scroll if needed */
+background-color: rgb(0,0,0); /* Fallback color */
+background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+}
+
+/* Style the tab */
+.tab {
+overflow: hidden;
+background-color: #00D3A9;
+}
+
+/* Style the buttons that are used to open the tab content */
+.tab button {
+background-color: inherit;
+float: left;
+border: none;
+outline: none;
+cursor: pointer;
+padding: 14px 16px;
+transition: 0.3s;
+}
+
+/* Change background color of buttons on hover */
+.tab button:hover {
+background-color: #00B39F;
+}
+
+/* Create an active/current tablink class */
+.tab button.active {
+background-color: #1E2117;
+color: "#fff"
+}
+
+/* Style the tab content */
+.tabcontent {
+padding: 6px 12px;
+border-top: none;
+}
+
+/* Modal Content/Box */
+.help-modal-content {
+background-color: #fefefe;
+margin: 15% auto; /* 15% from the top and centered */
+border: 1px solid #888;
+width: 60%; /* Could be more or less, depending on screen size */
+}
+
+/* The Close Button */
+.closed {
+color: black;
+float: right;
+font-size: 28px;
+font-weight: bold;
+}
+
+.closed:hover,
+.closed:focus {
+color: black;
+text-decoration: none;
+cursor: pointer;
+}
+
+.tooltip{
+position: absolute;
+top:1.8rem; 
+right: 0.5rem; 
+font-size: 22px;
+margin-right: 10px;
+}
+
+@media only screen and (max-width: 768px) {
+.tooltip {
+  font-size: 14px; /* Decrease the font size */
+}
+.tooltip i {
+  font-size: 18px;
+  position: relative; /* Set the position to relative */
+  top: -2rem;
+}
+}
+</style>
+
 {% assign pattern = page %}
 <div class="single-page">
 
@@ -30,9 +121,96 @@
 
       {% include partials/compatibility.html%}
       {% include copy-and-download.html %}
+      <br/>
+      <p class="catalog-subtext" style="text-align: inherit;"><span style="color: #fff; font-weight: bold;">Note: </span>Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import this design item</span> into Meshery <a style ="color: #00D3AF; text-decoration: none;"></a>"</p>
     </div>
     
+  </div>
+
+  <div id="myModal" class="help-modal">
+    <div class="help-modal-content">
+       
+        <div class="tab">
+            <span class="closed" style=" padding: 4px 15px">&times;</span>
+            <button class="tablinks active" onclick="openTab(event, 'MesheryUI')">Meshery UI</button>
+            <button class="tablinks" onclick="openTab(event, 'MesheryCLI')">Meshery CLI</button>
+          </div>
+          
+          <!-- Tab content -->
+          <div id="MesheryUI" class="tabcontent">
+            <h3>Meshery UI</h3>
+            <!-- <a href="{{ site.baseurl }}/assets/images/screens/pattern-import.mp4"
+        data-fancybox="images" data-caption="Import your patterns"> -->
+        <div style="text-align: center;">
+          <video width="98%" height="540" preload="metadata" controls>
+            <source src="{{ site.baseurl }}/assets/images/screens/pattern-import.mp4#t=0.01" type="video/mp4">
+          </video>
+        <!-- <iframe width="98%" height="540" preload="metadata" src="{{ site.baseurl }}/assets/images/screens/pattern-import.mp4#t=0.01" alt="Import your patterns" 
+        frameborder="0"
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen	></iframe> -->
+          </div>
+      </a>
+          </div>
+          
+          <div id="MesheryCLI" class="tabcontent" style="display: none;">
+            <h3>Meshery CLI</h3>
+            <p>1. Apply a pattern file. </p>
+            <div id="start-pattern" class="highlight-code" style="padding: 5px;">
+                <p class="code-box" style="height: 20px; line-height: 1px; color: white; white-space: nowrap; margin-left: 10px;"><code style="position: absolute;">
+                    mesheryctl pattern apply -f [file | URL]
+                 </code></p>
+                  <!-- copy to clipboard -->
+                  <a class="btn tooltip" data-clipboard-target="#start-brew"
+                    data-clipboard-text="mesheryctl pattern apply -f [file | URL]">
+                    <i class="far fa-copy"></i>
+                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 1.2rem; left: -80px;">Copy to clipboard</span>
+                  </a>
+              </div>
+            <p>2. Onboard an application.</p>
+            <div id="start-app" class="highlight-code" style="padding: 5px;">
+                <p class="code-box" style="height: 20px; line-height: 1px; color: white; white-space: nowrap; margin-left: 10px;"><code style="position: absolute;">
+                    mesheryctl app onboard -f [file-path]
+                 </code></p>
+                  <!-- copy to clipboard -->
+                  <a class="btn tooltip"  data-clipboard-target="#start-brew"
+                    data-clipboard-text="mesheryctl app onboard -f [file-path]">
+                    <i class="far fa-copy"></i>
+                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 1.2rem; left: -80px;">Copy to clipboard</span>
+                  </a>
+              </div>
+            <p>3. Apply a WASM filter file.</p>
+            <div id="start-pattern" class="highlight-code" style="padding: 5px;">
+                <p class="code-box" style="height: 20px; line-height: 1px; color: white; white-space: nowrap; margin-left: 10px ;"><code style="position: absolute;">
+                    mesheryctl exp filter apply --file [GitHub Link]
+                 </code></p>
+                  <!-- copy to clipboard -->
+                  <a class="btn tooltip"  data-clipboard-target="#start-brew"
+                    data-clipboard-text="mesheryctl exp filter apply --file [GitHub Link]">
+                    <i class="far fa-copy"></i>
+                    <span class="tooltiptext" style="font-size: 15px; width: 140px; height: 40px; padding: 0; line-height: 40px; top: 1.2rem; left: -80px;">Copy to clipboard</span>
+                  </a>
+              </div>
+          </div>
+          
+  </div>
   </div>
   <br>
   {% include related-discussion.html tag="meshery" %}
 </div>
+<script src="{{  site.baseurl }}/assets/js/help-modal.js"></script>
+<script>
+function openTab(evt, cityName) {
+    var i, tabcontent, tablinks;
+    tabcontent = document.getElementsByClassName("tabcontent");
+    for (i = 0; i < tabcontent.length; i++) {
+      tabcontent[i].style.display = "none";
+    }
+    tablinks = document.getElementsByClassName("tablinks");
+    for (i = 0; i < tablinks.length; i++) {
+      tablinks[i].className = tablinks[i].className.replace(" active", "");
+    }
+    document.getElementById(cityName).style.display = "block";
+    evt.currentTarget.className += " active";
+  }
+</script>

--- a/_includes/partials/individual-component.html
+++ b/_includes/partials/individual-component.html
@@ -46,6 +46,10 @@ padding: 6px 12px;
 border-top: none;
 }
 
+.tabcontent>h3{
+text-align: center;
+}
+
 /* Modal Content/Box */
 .help-modal-content {
 background-color: #fefefe;

--- a/_sass/catalog.scss
+++ b/_sass/catalog.scss
@@ -8,6 +8,9 @@
   color: var(--color-secondary-dark);
   font-size: 18px;
 }
+.tabcontent {
+  background: var(--background-light);
+}
 /* CARD-STYLES */
 .card {
   position: relative;

--- a/js/main.js
+++ b/js/main.js
@@ -45,3 +45,17 @@ btnscroll.on('click', function(e) {
   $('html, body').animate({scrollTop:0}, '0');
 });
 
+const copyBtns = document.querySelectorAll('.tooltip');
+copyBtns.forEach(copyBtn => {
+  copyBtn.addEventListener('click', () => {
+    const tooltip = copyBtn.querySelector('.tooltiptext');
+    const originalText = tooltip.textContent;
+    navigator.clipboard.writeText(copyBtn.getAttribute('data-clipboard-text'));
+    tooltip.textContent = 'Copied';
+    setTimeout(() => {
+      tooltip.textContent = originalText;
+    }, 3000);
+  });
+});
+
+


### PR DESCRIPTION

**Description**

This PR fixes 
1. Dark mode issue of help-modal under import design link and improve styling of code-blocks in mesheryctl tab

Earlier:

https://user-images.githubusercontent.com/90546692/231464856-ff940bb5-b7bc-4533-9fbe-871650a86ac0.mp4


Current:

https://user-images.githubusercontent.com/90546692/231465401-2c09fa8e-81ed-46e6-a35d-626318f70051.mp4

2. This pr fixes #1113 
Adding modal for instruction to import design

https://user-images.githubusercontent.com/90546692/231466051-a595e9a1-adbc-464a-8427-41a4c5703648.mp4





**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
