### PR TITLE
fixed copy-button-feedback-message-in-getting-started-section

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -68,10 +68,15 @@
 
 	function resetCopyText(element) {
 		let childElements = element.childNodes
+		if (childElements.length > 3) {
+			childElements[3].innerHTML = "Copy to clipboard";
+		} else {
 		childElements[1].innerHTML = "Copy URL";
 		childElements[1].style.color = 'white';
 		childElements[1].style.background = "#00b39fff";
+        }
 	}
+
 
 	var clipboard = new ClipboardJS('.btn');
 	clipboard.on('success', function (e) {
@@ -79,9 +84,13 @@
 		console.info('Text:', e.text);
 		console.info('Trigger:', e.trigger);
 		let childElements = e.trigger.childNodes;
+		if (childElements.length > 3) {
+		childElements[3].innerHTML = "Copied!";
+	} else {
 		childElements[1].innerHTML = "Copied";
 		childElements[1].style.color = 'white';
 		childElements[1].style.background = "#1a2421";
+	}
 		e.clearSelection();
 	});
 	clipboard.on('error', function (e) {


### PR DESCRIPTION
**Description**
 On Homepage in [Getting Started](https://meshery.io/) section, the copy button doesn't behave as it should, this started happening after merging PR #1023 : 
<img width="211" alt="Screenshot 2023-04-12 190431" src="https://user-images.githubusercontent.com/110674407/231476821-f8a73349-20ba-47d8-9b58-d3421f6d1d11.png">

This PR fixes the above issue : ( video preview uploading .... internet is slow :( )

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
