### PR TITLE
Open modal when clicked on individual designs in catalogs #1120

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,4 +1,3 @@
-<a class="external-link" href="{{pattern.url}}">
   <div class= "card link">  
     <div class="card-inner">
 
@@ -31,6 +30,5 @@
       </div>
     </div>
   </div>  
-</a>
 
 

--- a/_includes/wasm-card.html
+++ b/_includes/wasm-card.html
@@ -1,4 +1,3 @@
-<a class="external-link" href="{{pattern.url}}">
 <div class="link open-modal-btn">
     <div class= "card">
       <div class="card-inner">
@@ -23,4 +22,3 @@
     </div>
   </div>
     </div>
-</a>

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -35,7 +35,7 @@ permalink: /catalog
       <div class="column column-lg">
         {% if pattern.patternInfo and pattern.Status != "ComingSoon" %}
           {% include card.html %}
-        <!-- this is where the modal include is placed for future reference -->
+          {% include modal.html %}
         {% endif %}
       </div>
       
@@ -48,7 +48,7 @@ permalink: /catalog
       <div class="column column-lg">
         {% if pattern.filterInfo and pattern.Status != "ComingSoon" %}
           {% include wasm-card.html %}
-          <!-- this is where the modal include is placed for future reference -->
+          {% include modal.html %}
         {% endif %}
       </div>
       


### PR DESCRIPTION
**Description**
Earlier, whenever any design on catalog page was clicked a new page used to open but now a modal will appear for that design and from there the user can also navigate to the earlier page.

This PR fixes #1120

**Notes for Reviewers**

https://user-images.githubusercontent.com/88247268/233442393-c7984907-230a-4b14-a1e3-5f855b70331c.mp4



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 Signed-off-by: ishankhandelwals@gmail.com
