### PR TITLE
updated og-image

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,9 +38,9 @@
       name="twitter:image"
       content="https://raw.githubusercontent.com/meshery/meshery.io/master/assets/images/logos/meshery-gradient.png"
     />
-    <meta name="image" property="og:image" content="{{ site.baseurl }}/assets/images/logos/meshery-gradient.png" />
+    <meta name="image" property="og:image" content="https://raw.githubusercontent.com/meshery/meshery.io/master/assets/images/logos/meshery-gradient.png" />
     <meta property="og:type" content="website">
-    <meta name="og:image" content="/assets/images/logos/meshery-gradient.png/assets/images/logos/meshery-gradient.png" />
+    <meta name="og:image" content="https://raw.githubusercontent.com/meshery/meshery.io/master/assets/images/logos/meshery-gradient.png" />
 
   </head>
 

--- a/index.md
+++ b/index.md
@@ -2,5 +2,5 @@
 layout: home
 title: Meshery | The Kubernetes and Cloud Native Manager - an extensible developer platform
 description: As a CNCF project, Meshery is the open source, cloud native manager, with multi-cluster Kubernetes management.
-image: images/logos/meshery-gradient.png
+image: assets/images/logos/meshery-gradient.png
 ---


### PR DESCRIPTION
**Description**

This PR updates the content attribute of meta tags for opengraph images to reference to correct address : https://raw.githubusercontent.com/meshery/meshery.io/master/assets/images/logos/meshery-gradient.png
<br>

<img width="498" alt="Screenshot 2023-04-22 200918" src="https://user-images.githubusercontent.com/110674407/233791145-c5c61867-0a02-426d-96e9-06d043a10393.png"><img width="797" alt="Screenshot 2023-04-22 200858" src="https://user-images.githubusercontent.com/110674407/233791132-f22ad0ae-637f-4f9c-aa48-4390b321079f.png">



**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
