### PR TITLE
Added support for dark mode in twitter timeline widget in Footer Element closes #1242

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     ffi (1.15.5)
-    ffi (1.15.5-x64-mingw32)
     forwardable-extended (2.6.0)
     google-protobuf (3.21.12)
     http_parser.rb (0.8.0)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -40,7 +40,7 @@
 
 			<ul class="feed">
 				<!-- <div class="col l4"> -->
-				<a class="twitter-timeline" id="twitter-timeline" data-width="320" data-height="320" data-theme="light"
+				<a class="twitter-timeline" data-width="320" data-height="320" data-theme="light"
 					data-link-color="#62ACCD" href="https://twitter.com/mesheryio"
 					data-chrome="nofooter circularborders noscrollbar">Tweets by Meshery</a>
 				<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -40,7 +40,7 @@
 
 			<ul class="feed">
 				<!-- <div class="col l4"> -->
-				<a class="twitter-timeline" data-width="320" data-height="320" data-theme="light"
+				<a class="twitter-timeline" id="twitter-timeline" data-width="320" data-height="320" data-theme="light"
 					data-link-color="#62ACCD" href="https://twitter.com/mesheryio"
 					data-chrome="nofooter circularborders noscrollbar">Tweets by Meshery</a>
 				<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
@@ -141,14 +141,38 @@
 		document.body.classList.toggle("dark-mode")
 		let layer5Logos = document.querySelectorAll("#layer5-logo");
 		let allLogos = document.querySelectorAll("#logo-dark-light");
+		let twitterTimeline = document.querySelector(".twitter-timeline");
+  		let parentTwitterTimeline = twitterTimeline.parentNode;
 		// console.log(allLogos)
 		if (document.body.classList.contains("dark-mode")) {
 			layer5Logos.forEach(e => e.src = '../assets/images/company-logo/layer5-dark-mode-logo.svg')
 			allLogos.forEach(e => e.src = e.dataset.logoForDark)
+		    twitterTimeline.dataset.theme = "dark";
 		} else {
 			layer5Logos.forEach(e => e.src = '../assets/images/company-logo/layer5-no-trim.svg')
 			allLogos.forEach(e => e.src = e.dataset.logoForLight)
+		    twitterTimeline.dataset.theme = "light";
 		}
+
+		parentTwitterTimeline.removeChild(twitterTimeline);
+
+		// Create a new Twitter timeline element
+		let newTimeline = document.createElement('a');
+		newTimeline.innerHTML = 'Tweets by Meshery';
+		newTimeline.setAttribute('class', 'twitter-timeline');
+		newTimeline.setAttribute('data-width', '320');
+		newTimeline.setAttribute('data-height', '320');
+		newTimeline.setAttribute('data-theme', twitterTimeline.dataset.theme);
+		newTimeline.setAttribute('data-link-color', '#62ACCD');
+		newTimeline.setAttribute('data-chrome', 'nofooter circularborders noscrollbar');
+		newTimeline.setAttribute('href', 'https://twitter.com/mesheryio');
+
+		// Append the new Twitter timeline element to the parent
+		parentTwitterTimeline.appendChild(newTimeline);
+
+		// Load the Twitter widget for the new timeline
+		window.twttr.widgets.load();
+
 		if (document.body.classList.contains("dark-mode")) {
 			localStorage.setItem("mode", "dark-mode")
 		} else {


### PR DESCRIPTION
**Description**

This PR fixes #1242 

**Notes for Reviewers**
I have added dark mode functionality for twitter timeline widget for dark mode.

Implementation details: 
first, i had tried using changing the data-theme attribute of the <a> tag of twitter widget, it was working but it required reloading the page to see the changes, so it was not feasible at all.
Now, what I have done is for dark mode and light mode, whenever toggle happens, it creates a new widget and then appends to the page, so no refresh is required.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

### Screenshots: 
- dark mode
![image](https://github.com/meshery/meshery.io/assets/93506927/db21f408-7dd5-4920-81ec-59940be98247)

- light mode
![image](https://github.com/meshery/meshery.io/assets/93506927/b547a698-3c3f-4e3c-8626-a9643ad82615)
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
