### PR TITLE
wasm-filter-fix-and-remove-redundancy-in-categories

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -3,7 +3,7 @@
 
       <div class="front">
         <div class="chip">
-          <small class="pattern-type"> {{pattern.type | downcase }}</small>
+          <small class="pattern-type"> {{pattern.type | upcase }}</small>
         </div>
         <h4 class="pattern-name">{{pattern.name}}</h4>
         <div class="pattern-image-container">

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -3,7 +3,7 @@
 
       <div class="front">
         <div class="chip">
-          <small class="pattern-type"> {{pattern.type}}</small>
+          <small class="pattern-type"> {{pattern.type | downcase }}</small>
         </div>
         <h4 class="pattern-name">{{pattern.name}}</h4>
         <div class="pattern-image-container">

--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -7,11 +7,11 @@
     <div class="chip chip-modal">
       {% if pattern.filters.type == "wasm filter" %}
       <a style="text-decoration: none; color: #333;" href="{{ site.baseurl }}/catalog/webassembly">
-        <h6 class="pattern-type"> {{pattern.filters.type}}</h6>
+        <h6 class="pattern-type"> {{pattern.filters.type }}</h6>
         {%else%}
         <a style="text-decoration: none; color: #333;" href="{{ site.baseurl }}/catalog/{{ pattern.type | slugify }}">
           {%endif%}
-          <h6 class="pattern-type"> {{pattern.type | downcase }}</h6>
+          <h6 class="pattern-type"> {{pattern.type | upcase }}</h6>
         </a>
     </div>
     <div class="modal-content">

--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -11,7 +11,7 @@
         {%else%}
         <a style="text-decoration: none; color: #333;" href="{{ site.baseurl }}/catalog/{{ pattern.type | slugify }}">
           {%endif%}
-          <h6 class="pattern-type"> {{pattern.type}}</h6>
+          <h6 class="pattern-type"> {{pattern.type | downcase }}</h6>
         </a>
     </div>
     <div class="modal-content">

--- a/_includes/patterns-filter.html
+++ b/_includes/patterns-filter.html
@@ -213,6 +213,14 @@
   // import all integrations data
   import data from "{{ site.baseurl }}/integrations/data.js";
 
+  // add wasmFilter to data array
+  const wasmFilter = {
+    "name": "wasm filter",
+    "color": "../assets/images/integration/webassembly_logo.svg",
+    "white": "../assets/images/integration/webassembly_logo.svg"
+  };
+  data.push(wasmFilter);
+
   // Function to compare the names of all catalog entries by technology
   // TODO: Improve so that catalog entries can be sorted by pattern name, too.
   function compare(a, b) {
@@ -247,7 +255,7 @@
       const filter = patternCards[i].getAttribute("filter")
       cardCompatibility.push(filter);
       const type = patternCards[i].getAttribute("type")
-      if(type) cardType.add(type);
+      if(type && type !== "wasm filter") cardType.add(type.toLowerCase()); 
       const technology = patternCards[i].getAttribute("technology")
       if(technology) cardTechnology.add(technology);
   }
@@ -385,7 +393,7 @@
     // Show all cards if "All" radio button is selected
     const patternCards = document.querySelectorAll(".patternCard");
     for (let j = 0; j < patternCards.length; j++) {
-      const filter = patternCards[j].getAttribute("type");
+      const filter = patternCards[j].getAttribute("type").toLowerCase();
       let showCard = false;
       if (value === "All" || filter.includes(value)) {
         showCard = true;

--- a/_includes/patterns-filter.html
+++ b/_includes/patterns-filter.html
@@ -215,7 +215,7 @@
 
   // add wasmFilter to data array
   const wasmFilter = {
-    "name": "wasm filter",
+    "name": "WASM Filter",
     "color": "../assets/images/integration/webassembly_logo.svg",
     "white": "../assets/images/integration/webassembly_logo.svg"
   };

--- a/_includes/wasm-card.html
+++ b/_includes/wasm-card.html
@@ -3,7 +3,7 @@
       <div class="card-inner">
         <div class="front">
        <div class="chip">
-           <small class="pattern-type"> {{pattern.filters.type}}</small>
+           <small class="pattern-type"> {{pattern.filters.type | upcase }}</small>
        </div>
        <h4 class="pattern-name">{{pattern.name}}</h4>
        <img class= "pattern-filter-image" src="{{pattern.image}}" />

--- a/_includes/wasm.html
+++ b/_includes/wasm.html
@@ -5,7 +5,7 @@
       <div class= "card">
         
          <div class="chip">
-             <small class="pattern-type"> {{filter.filters.type}}</small>
+             <small class="pattern-type"> {{filter.filters.type }}</small>
          </div>
          <h4 class="pattern-name">{{filter.name}}</h4>
          <img class= "pattern-filter-image" src="{{filter.image}}"/>
@@ -22,7 +22,7 @@
     <div>
       <button class = "modal-close close">&times;</button>
       <div class="chip chip-modal">
-        <h6 class="pattern-type"> {{filter.filters.type}}</h6>
+        <h6 class="pattern-type"> {{filter.filters.type | upcase }}</h6>
     </div>
     <p><div class="modal-image-container"><div class="modal-image" ><img src="{{filter.image}}" /> <h4 class="related-patterns">Related Patterns</h4>
 {% include related-patterns.html %}

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -47,7 +47,7 @@ permalink: /catalog
   and pattern.Status != "ComingSoon" %}
   <div
     class="column column-lg patternCard"
-    filter="wasm filter"
+    filter="WASM Envoy Filter"
     type="{{ pattern.filters.type }}"
     technology="{{ pattern.technology }}"
   >

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -47,7 +47,7 @@ permalink: /catalog
   and pattern.Status != "ComingSoon" %}
   <div
     class="column column-lg patternCard"
-    filter="{{ pattern.compatibility }}"
+    filter="wasm filter"
     type="{{ pattern.filters.type }}"
     technology="{{ pattern.technology }}"
   >

--- a/catalog/technology/webassembly.html
+++ b/catalog/technology/webassembly.html
@@ -4,4 +4,18 @@ permalink: /catalog/webassembly
 title: Cloud Native Catalog
 filter: wasm filter
 ---
-{% include catalog-filters.html %}
+<div class="row">
+    {% for pattern in site.data.wasm %} {% if pattern.filterInfo
+        and pattern.Status != "ComingSoon" %}
+        <div
+          class="column column-lg patternCard"
+          filter="{{ pattern.compatibility }}"
+          type="{{ pattern.filters.type }}"
+          technology="{{ pattern.technology }}"
+        >
+          {% include wasm-card.html %}
+          <!-- modal included -->
+          {% include modal.html %}
+        </div>
+        {% endif %} {% endfor %}
+</div>


### PR DESCRIPTION
**Description**

This PR fixes #1304 
- removes redundancy in categories ( like Deployment, deployment)
- list wasm filter in Technology section
- wasm filters are now accessible at catalog/webassembly


**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
