### PR TITLE
wasm-filter-fix

### DIFF
--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -2,12 +2,12 @@
   <div class="click-container">
     <div style="display: flex; justify-content: space-between;">
       <button style="margin: 0;" class="modal-close close">&times;</button>
-      {% include read-more.html %}
+      <!-- {% include read-more.html %} -->
     </div>
     <div class="chip chip-modal">
       {% if pattern.filters.type == "wasm filter" %}
       <a style="text-decoration: none; color: #333;" href="{{ site.baseurl }}/catalog/webassembly">
-        <h6 class="pattern-type"> {{pattern.filters.type }}</h6>
+        <h6 class="pattern-type"> {{pattern.filters.type | upcase }}</h6>
         {%else%}
         <a style="text-decoration: none; color: #333;" href="{{ site.baseurl }}/catalog/{{ pattern.type | slugify }}">
           {%endif%}

--- a/_includes/wasm-card.html
+++ b/_includes/wasm-card.html
@@ -1,4 +1,3 @@
-<a  href="{{pattern.url}}">
 <div class="link open-modal-btn">
     <div class= "card">
       <div class="card-inner">
@@ -22,5 +21,4 @@
      <div class="back"></div>
     </div>
   </div>
-  </div>
-</a>    
+  </div>    

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -47,13 +47,14 @@ permalink: /catalog
   and pattern.Status != "ComingSoon" %}
   <div
     class="column column-lg patternCard"
-    filter="WASM Envoy Filter"
+    filter="WASM Filter"
     type="{{ pattern.filters.type }}"
     technology="{{ pattern.technology }}"
   >
     {% include wasm-card.html %}
     <!-- modal included -->
     {% include modal.html %}
+    {% include card-modal.html %}
   </div>
   {% endif %} {% endfor %} {% for pattern in catalog %} {% if
   pattern.patternInfo and pattern.Status == "ComingSoon" %}

--- a/catalog/technology/webassembly.html
+++ b/catalog/technology/webassembly.html
@@ -16,6 +16,7 @@ filter: wasm filter
           {% include wasm-card.html %}
           <!-- modal included -->
           {% include modal.html %}
+          {% include card-modal.html %}
         </div>
         {% endif %} {% endfor %}
 </div>


### PR DESCRIPTION
**Description**

This PR
 - lists wasm filter in technology section
 - on clicking on wasm cards, opens a modal with information.
**Notes for Reviewers**

<img width="246" alt="Screenshot 2023-08-02 090124" src="https://github.com/meshery/meshery.io/assets/110674407/819b0403-b22a-44a5-a2b4-faa7cefc4a19">
<img width="635" alt="Screenshot 2023-08-02 090152" src="https://github.com/meshery/meshery.io/assets/110674407/b09d3fac-f931-4132-aa05-77eab19f30f9">


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
