### PR TITLE
fix#1402 blog spacing w/signoff

### DIFF
--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -40,18 +40,19 @@
 
 	.blog-navigation {
 		font-size: 14px;
-		display: block;
+		display: flex;
+		justify-content: space-between;
 		width: auto;
 		overflow: hidden;
-		a {
-			display: block;
-			float: left;
-			margin: 1em 0;
-		}
-
-		.next {
-			text-align: right;
-		}
+	}
+	
+	.blog-navigation a {
+		display: block;
+		margin: 1em 0;
+	}
+	
+	.next {
+		text-align: right;
 	}
 
 	.post-details {


### PR DESCRIPTION
Lack of Spacing Between Next and Previous Blog Links in Blog Pagination

This PR fixes #1402 

Added the flex in place of block and justify-content to the space between,  ensuring "Prev" is on the left and "Next" is on the right.