### PR TITLE
Fixed the overlapping issue of coming soon image in the Cloud native catalog page

### DIFF
--- a/_sass/catalog-features.scss
+++ b/_sass/catalog-features.scss
@@ -210,7 +210,7 @@
     border: 0;
   }
   .patterns-coming-soon{
-    width: 40%;
-    margin-right: 0;
+    max-width: 30%;
+    margin-right: 1rem;
   }
 }

--- a/_sass/catalog-features.scss
+++ b/_sass/catalog-features.scss
@@ -210,7 +210,7 @@
     border: 0;
   }
   .patterns-coming-soon{
-    max-width: 30%;
-    margin-right: 1rem;
+   max-width: 30%;
+   margin-right: 1rem;
   }
 }

--- a/_sass/catalog-features.scss
+++ b/_sass/catalog-features.scss
@@ -211,6 +211,6 @@
   }
   .patterns-coming-soon{
    max-width: 30%;
-   margin-right: 1rem;
+   margin-right:1rem;
   }
 }


### PR DESCRIPTION
**Description**
There was an issue where the "coming soon" image in the cloud native catalog page was occupying the entire available space, causing the main image to be hidden from view on the mobile device with width under 600px.


This PR fixes #1384 

**Notes for Reviewers**
![Screenshot (411)](https://github.com/meshery/meshery.io/assets/96014425/c91e172a-6dcf-41ca-ba33-7c1ca5cf0436)


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
