### PR TITLE
[Catalog] Explicitly set `imageURL` when catalog_data do not have image attribute

### DIFF
--- a/.github/workflows/add-catalog.yml
+++ b/.github/workflows/add-catalog.yml
@@ -49,7 +49,7 @@ jobs:
             patternName="$(jq -r .[$idx].name temp.json)"
             patternImageURL="$(jq -r .[$idx].catalog_data.imageURL temp.json)"
             if [[ $patternImageURL == "null" || $patternImageURL == "" ]]; then
-              patternImageURL=/assets/images/patterns/service-mesh.svg
+              patternImageURL=https://raw.githubusercontent.com/layer5labs/meshery-extensions-packages/master/action-assets/design-assets/$designId.png
             fi
             compatibility=""
             echo "contentID=$designId" >> $GITHUB_OUTPUT
@@ -115,6 +115,14 @@ jobs:
           URL: 'https://raw.githubusercontent.com/meshery/meshery.io/master/$MESHERY_CATALOG_FILES_DIR/$designId.yaml'
           downloadLink: $designId.yaml
           ---" > ./collections/_catalog/"$(echo $patternType | tr '[:upper:]' '[:lower:]')"/$designId.md
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GH_ACCESS_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/meshery/meshery.io/actions/workflows/meshmap.yml/dispatches" \
+          -d '{"ref":"master","inputs":{"contentID":"'$designId'","assetLocation":"'$patternImageURL'"}}'
+          
           done
           rm temp.json
           rm err.txt
@@ -220,16 +228,3 @@ jobs:
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit_options: '--signoff'
           commit_message: '[Catalog] Update Catalog items'
-  call_meshmap_snapshot:
-    secrets: inherit
-    uses: ./.github/workflows/meshmap.yml
-    needs: [UpdateCloudNativeCatalog]
-    with:
-      contentID: ${{ github.event.client_payload.contentID }}
-      assetLocation: ${{ github.event.client_payload.assetURL }}
-  output_resource_url:
-    needs: [call_meshmap_snapshot]
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Resource URL"
-      run: echo ${{needs.call_meshmap_snapshot.outputs.resource_url}}

--- a/.github/workflows/meshmap.yml
+++ b/.github/workflows/meshmap.yml
@@ -2,7 +2,16 @@ name: MeshMap Screenshot Service
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types: [opened, synchronize, reopened]
-  
+  workflow_dispatch:
+    inputs:
+      contentID: 
+        description: ID of the design to render.
+        required: true
+        type: string
+      assetLocation:
+        required: true
+        type: string
+        description: Remote location where the generated asset (screenshot) for the design will be stored.
   workflow_call:
     inputs:
       contentID: 
@@ -40,6 +49,10 @@ jobs:
         with:
           path: action
           repository: layer5labs/meshmap-snapshot
+      - run: |
+         echo ${{ inputs.contentID }}
+         echo ${{ inputs.assetLocation }}
+        shell: bash
       - id: test_result
         uses: layer5labs/MeshMap-Snapshot@master
         with:


### PR DESCRIPTION
**Description**

This PR fixes #
The `image` attribute was set to the default icon when the catalog_data didn't have `imageURL` attribute. The behaviour is now changed to explicitly set the `image` attribute in such cases. (The `imageURL` attribute would be empty for existing catalogs only.)
**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
