### PR TITLE
[Docs] Updated the wrong links to new correct links in catalog page

### DIFF
--- a/_includes/help-modal.html
+++ b/_includes/help-modal.html
@@ -89,7 +89,7 @@ Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import any cata
           <!-- Tab content -->
           <div id="MesheryUI" class="tabcontent">
             <h3>Meshery UI</h3>
-            <p>To import designs, visit <a href="https://docs.meshery.io/guides/meshery-design#import-your-designs">docs</a></p>
+            <p>To import designs, visit <a href="https://docs.meshery.io/guides/configuration-management/importing-apps#import-apps-using-meshery-ui" target="_blank">docs</a></p>
             
             <!-- <a href="{{ site.baseurl }}/assets/images/screens/pattern-import.mp4"
 				data-fancybox="images" data-caption="Import your patterns"> -->
@@ -107,7 +107,7 @@ Easily <span style="color: #00D3A9; cursor: pointer;" id="myBtn">import any cata
           
           <div id="MesheryCLI" class="tabcontent" style="display: none;">
             <h3>Meshery CLI</h3>
-            <p>Import using mesheryctl, visit <a href="https://docs.meshery.io/installation/mesheryctl">docs</a> for steps.</p>
+            <p>Import using mesheryctl, visit <a href="https://docs.meshery.io/guides/configuration-management/importing-apps#import-apps-using-meshery-cli" target="_blank">docs</a> for steps.</p>
             
             <!-- <h3>Meshery CLI</h3> -->
             <p>1. Apply a pattern file. </p>


### PR DESCRIPTION
**Description**
This PR fixes #1600 

- Removed wrong link and added correct link in  **Meshery UI & Meshery CLI** modal on catalog page
- When clicked a new page is opened rather than redirecting the user

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
