### PR TITLE
[bug/ci] Fixes failing Catalog Workflow

### DIFF
--- a/.github/workflows/add-catalog.yml
+++ b/.github/workflows/add-catalog.yml
@@ -63,11 +63,19 @@ jobs:
             
             compatibility=""
             echo "contentID=$designId" >> $GITHUB_OUTPUT
+
+            # sets default
+            if [[ $patternType == "null" ]]; then
+              patternType="Deployment"
+            fi
+
+            # updates patternType by converting upper to lower case and switching spaces with hypen
+            updatedPatternType=$(echo $patternType | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
             # check if directory doesn't exists; then create it
-            if [ ! -d "./collections/_catalog/"$(echo $patternType | tr '[:upper:]' '[:lower:]')"" ]; then
-              echo "$(echo $patternType | tr '[:upper:]' '[:lower:]') doesn't exist."
-              echo "Creating directory...$(echo $patternType | tr '[:upper:]' '[:lower:]')"
-              mkdir "./collections/_catalog/"$(echo $patternType | tr '[:upper:]' '[:lower:]')""
+            if [ ! -d "./collections/_catalog/"$updatedPatternType"" ]; then
+              echo "$updatedPatternType doesn't exist."
+              echo "Creating directory... $updatedPatternType"
+              mkdir "./collections/_catalog/"$updatedPatternType""
             fi
 
             if [[ $patternInfo == "null" ]]; then
@@ -76,10 +84,6 @@ jobs:
 
             if [[ $patternCaveats == "null" ]]; then
               patternCaveats="\"\""
-            fi
-
-            if [[ $patternType == "null" ]]; then
-              patternType="Deployment"
             fi
 
             compatLength=$(jq -r ".[$idx].catalog_data.compatibility | length" temp.json)

--- a/.github/workflows/add-catalog.yml
+++ b/.github/workflows/add-catalog.yml
@@ -69,7 +69,7 @@ jobs:
               patternType="Deployment"
             fi
 
-            # updates patternType by converting upper to lower case and switching spaces with hypen
+            # updates patternType by converting upper to lower case and switching spaces with hyphen
             updatedPatternType=$(echo $patternType | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
             # check if directory doesn't exists; then create it
             if [ ! -d "./collections/_catalog/"$updatedPatternType"" ]; then


### PR DESCRIPTION
**Description**

This PR fixes the failing catalog workflow. https://github.com/meshery/meshery.io/actions/runs/8013273008/job/21890041083

Handles the case when the patternType is two or more words, like `traffic management` by trimming the space and adding hyphen `-`.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
