### PR TITLE
Lazy load scripts in modal

### DIFF
--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -49,10 +49,28 @@
           {% include partials/compatibility.html %}
         {% include copy-and-download.html %}
       </div>
-    </div>
-     
- <script src="{{ site.baseurl }}/assets/js/catalog-modal.js"></script>
- <script src="{{ site.baseurl }}/assets/js/thumbnail-clickable.js"></script>
-   
+    </div>   
   <!-- </div> -->
 </div>
+
+<script>
+  // Lazy load the catalog-modal.js script
+  function loadCatalogModalScript() {
+    const script = document.createElement('script');
+    script.src = "{{ site.baseurl }}/assets/js/catalog-modal.js";
+    document.body.appendChild(script);
+  }
+
+  // Lazy load the thumbnail-clickable.js script
+  function loadThumbnailClickableScript() {
+    const script = document.createElement('script');
+    script.src = "{{ site.baseurl }}/assets/js/thumbnail-clickable.js";
+    document.body.appendChild(script);
+  }
+
+  // Lazy load scripts when the modal is opened
+  document.getElementById('open-modal').addEventListener('click', function() {
+    loadCatalogModalScript();
+    loadThumbnailClickableScript();
+  });
+</script>


### PR DESCRIPTION
**Description**
The last 2 scripts were the reason that meshery.io/catalog was loading slowly. I'm not sure why we need them, but now they're loading lazily.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commitments

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
