### PR TITLE
Fix Catalog YAML Generation Issue with Compatibility List Indentation

### DIFF
--- a/assets/artifact-hub-pkg/package.go
+++ b/assets/artifact-hub-pkg/package.go
@@ -225,7 +225,7 @@ userName: %s
 userAvatarURL: %s
 type: %s
 compatibility: 
-  %s
+%s
 patternId: %s
 image: %s
 patternInfo: |


### PR DESCRIPTION
**Description**

This PR fixes #

This PR fixes an issue with the catalog file YAML generation where the first item in the compatibility list had an extra leading space, causing incorrect indentation and resulting in invalid YAML.

Issue
```yaml
layout: item
name: Argo CD w/Dex
userId: 090e7114-509a-4046-81f1-9c5fb8daf724
userName: Lee Calcote
userAvatarURL: https://pbs.twimg.com/profile_images/880205475643441152/V_vhfnzb_400x400.jpg
type: resiliency
compatibility: 
          - argo-cd           // Extra space (Issue here)
        - argocd-operator
patternId: 4690406b-60e7-4c82-87c3-20b22862f5b5
```
**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
