### PR TITLE
Do escape encoding of design name before inserting into yaml

### DIFF
--- a/assets/artifact-hub-pkg/package.go
+++ b/assets/artifact-hub-pkg/package.go
@@ -217,6 +217,12 @@ func writePatternFile(pattern CatalogPattern, patternType, patternInfo, patternC
 	}
 	userFullName := fmt.Sprintf("%s %s", userInfo.FirstName, userInfo.LastName)
 
+	// Use yaml.Marshal for pattern.Name to ensure proper escaping
+	nameYAML, err := yaml.Marshal(pattern.Name)
+	if err != nil {
+		return err
+	}
+
 	content := fmt.Sprintf(`---
 layout: item
 name: %s
@@ -234,7 +240,7 @@ patternCaveats: |
   %s
 URL: 'https://raw.githubusercontent.com/meshery/meshery.io/master/%s/%s/design.yml'
 downloadLink: %s/design.yml
----`, pattern.Name, pattern.UserID, userFullName, userInfo.AvatarURL, patternType, compatibility, pattern.ID, patternImageURL, patternInfo, patternCaveats, mesheryCatalogFilesDir, pattern.ID, pattern.ID)
+---`, strings.TrimSpace(string(nameYAML)), pattern.UserID, userFullName, userInfo.AvatarURL, patternType, compatibility, pattern.ID, patternImageURL, patternInfo, patternCaveats, mesheryCatalogFilesDir, pattern.ID, pattern.ID)
 
 	if err := ioutil.WriteFile(fmt.Sprintf(filepath.Join("..", "..", "collections", "_catalog", patternType, pattern.ID+".md")), []byte(content), 0644); err != nil {
 		return utils.ErrWriteFile(err, filepath.Join("..", "..", "collections", "_catalog", patternType, pattern.ID+".md"))


### PR DESCRIPTION
**Description**

This PR fixes #

This PR addresses an issue where special characters in catalog name were causing incorrect YAML formatting during catalog file generation. This was causing invalid YAML due to unescaped characters like [, ], /, and - in pattern names.

This issue is fixed by making sure we do escape encoding before inserting them to YAML which make sure of YAML is valid and we handle special character properly

**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
