### PR TITLE
Decode pattern info and caveats before adding to ArtifactHub package file

### DIFF
--- a/assets/artifact-hub-pkg/package.go
+++ b/assets/artifact-hub-pkg/package.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,6 +168,14 @@ func getCompatibility(compatibility []string) string {
 	return strings.Join(compatLines, "\n")
 }
 
+func decodeURIComponent(encodedURI string) (string, error) {
+	decoded, err := url.QueryUnescape(encodedURI)
+	if err != nil {
+		return "", err
+	}
+	return decoded, nil
+}
+
 func writePatternFile(pattern CatalogPattern, patternType, patternInfo, patternCaveats, compatibility, patternImageURL string) error {
 	dir := filepath.Join("..", "..", mesheryCatalogFilesDir, pattern.ID)
 	designFilePath := filepath.Join(dir, "design.yml")
@@ -195,8 +204,18 @@ func writePatternFile(pattern CatalogPattern, patternType, patternInfo, patternC
 	if pattern.CatalogData.PatternInfo == "" {
 		pattern.CatalogData.PatternInfo = pattern.Name
 	}
+
+	pattern.CatalogData.PatternInfo, err = decodeURIComponent(pattern.CatalogData.PatternInfo)
+	if err != nil {
+		return ErrDecodingContent(err)
+	}
+	
+	pattern.CatalogData.PatternCaveats, err = decodeURIComponent(pattern.CatalogData.PatternCaveats)
+	if err != nil {
+		return ErrDecodingContent(err)
+	}
    
-  version := pattern.CatalogData.PublishedVersion
+  	version := pattern.CatalogData.PublishedVersion
 	if version == "" {
 		version = semver.New(0, 0, 1, "", "").String()
 	}
@@ -311,4 +330,18 @@ func ErrReadRespBody(err error) error {
 		[]string{fmt.Sprintf("Unable to read the response body from the server.\nError: %v", err)},
 		[]string{"The response body might be too large", "There could be a network issue"},
 		[]string{"Ensure the server returns a valid and readable response body."})
+}
+
+func ErrDecodingContent(err error) error {
+	return meshkitErrors.New(ErrReadRespBodyCode, meshkitErrors.Alert,
+		[]string{"Error decoding content"},
+		[]string{fmt.Sprintf("Unable to decode design caveats and info.\nError: %v", err)},
+		[]string{
+			"Content may be an invalid string.",
+			"The content might be missing or incomplete.",
+		},
+		[]string{
+			"Ensure that the content is a valid string.",
+			"Check if the content is complete and not truncated.",
+		})
 }


### PR DESCRIPTION
**Description**

This PR fixes #

Catalog content is in URI format and during artifact-hub package generation we add content without decoding it, which causes issue of non readable content getting published on artifact hub, this PR fixes this issue by making sure we first decode it and then add it to artifact hub package file

yaml.marshal will take care of multi line and special characters

**Notes for Reviewers**

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
