### PR TITLE
Fixes the padding issue on the branding page

### DIFF
--- a/_sass/brand.scss
+++ b/_sass/brand.scss
@@ -31,6 +31,7 @@
 .brand-kit {
     width: 60%;
     z-index: 5; /* Make sure this layer is above the background images */
+    padding: 5%;
 }
 
 .brand-kit h1 {
@@ -238,7 +239,7 @@
     .brand-kit {
         width: 100%;
         text-align: center; /* Center align the text for mobile */
-        padding: 0%;
+        padding: 5%;
     }
 
     .brand-kit h1 {


### PR DESCRIPTION
**Description**

This PR fixes #1811

**Notes for Reviewers**

Before
The issue was that the hero section on the brand page was not having any padding .
![image](https://github.com/jaysomani/meshery.io/assets/69755312/09530a08-f2aa-4336-a1c2-deceda229521)


After 
Added 5% padding to the hero section with confirmation
![image](https://github.com/jaysomani/meshery.io/assets/69755312/45446639-e1e5-4e01-8fd3-db71d59b9fcb)


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
