### PR TITLE
Added linux foundation trademark disclaimer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,6 +39,7 @@
 			<div class="text">Confidently wrangling cloud native infrastructure</div>
 			<div class="text"><a href="https://github.com/meshery/meshery/blob/master/CODE_OF_CONDUCT.md">Code of
 					Conduct</a></div>
+			<div class="text"><a href ="https://www.linuxfoundation.org/legal/trademark-usage">The Linux Foundation. Meshery has registered trademarks and uses trademarks</a></div>
 		</div>
 	</div>
 </footer>


### PR DESCRIPTION
**Description**

This PR fixes #1831 

**Notes for Reviewers**
added description in footer "The Linux Foundation. Meshery has registered trademarks and uses trademarks"
and a link to "https://www.linuxfoundation.org/legal/trademark-usage"

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
