### PR TITLE
[Fix] Overlap view docs button in mobile view issue

### DIFF
--- a/_sass/features.scss
+++ b/_sass/features.scss
@@ -99,6 +99,7 @@
     width: 100%;
     height: 45vh;
     margin-right: 20px;
+    margin-top: 3rem;
     -webkit-flex: 1;
         flex: 1;
     


### PR DESCRIPTION
**Description**
Fix this issue by adding a top margin of 3rem, as we did for the other images.

This PR fixes #1839 

Screenshot
![image](https://github.com/user-attachments/assets/c3425e87-4a30-4125-8a94-3019b54cc8a7)


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
