### PR TITLE
Corrected Malformatted YAML in Catalog Content

### DIFF
--- a/collections/_catalog/deployment/29b94780-865c-460b-b852-cc5c31730561.md
+++ b/collections/_catalog/deployment/29b94780-865c-460b-b852-cc5c31730561.md
@@ -14,33 +14,33 @@ image: https://raw.githubusercontent.com/layer5labs/meshery-extensions-packages/
 patternInfo: |
   The design represented by the nginx-deployment.yaml file sets up a basic web server infrastructure using Kubernetes resources.
 
-Key Components:
-Namespace (nginx-namespace):
+  Key Components:
+  Namespace (nginx-namespace):
 
-A separate namespace called nginx-namespace is created to isolate and organize the Nginx application and its resources from other applications running in the cluster.
-Deployment (nginx-deployment):
+  A separate namespace called nginx-namespace is created to isolate and organize the Nginx application and its resources from other applications running in the cluster.
+  Deployment (nginx-deployment):
 
-Deploys a web server using the Nginx image (nginx:latest).
-Two replicas (instances) of the Nginx server are created, ensuring high availability and load distribution across multiple pods.
-Each pod in the deployment runs the Nginx container and listens on port 80.
-Service (nginx-service):
+  Deploys a web server using the Nginx image (nginx:latest).
+  Two replicas (instances) of the Nginx server are created, ensuring high availability and load distribution across multiple pods.
+  Each pod in the deployment runs the Nginx container and listens on port 80.
+  Service (nginx-service):
 
-Exposes the Nginx application to the external network via a LoadBalancer service type.
-The service forwards traffic from external clients to the Nginx pods on port 80, making the web server accessible outside the cluster.
-The service ensures that traffic is balanced between the two Nginx pods.
-Purpose of the Design:
-This design demonstrates how to deploy a simple, scalable web server using Kubernetes. By visualizing this in Meshery, you can:
+  Exposes the Nginx application to the external network via a LoadBalancer service type.
+  The service forwards traffic from external clients to the Nginx pods on port 80, making the web server accessible outside the cluster.
+  The service ensures that traffic is balanced between the two Nginx pods.
+  Purpose of the Design:
+  This design demonstrates how to deploy a simple, scalable web server using Kubernetes. By visualizing this in Meshery, you can:
 
-Understand the relationship between different Kubernetes resources (Namespace, Deployment, and Service).
-Observe how traffic flows from external clients through the LoadBalancer to the Nginx pods.
-Learn the basics of deploying and managing stateless applications in Kubernetes.
-Use this as a foundation to explore more advanced Kubernetes concepts like autoscaling, rolling updates, and integration with service meshes.
-In summary, this design sets up a highly available Nginx web server with external access and load balancing, making it a fundamental example of how to deploy and expose applications using Kubernetes.
+  Understand the relationship between different Kubernetes resources (Namespace, Deployment, and Service).
+  Observe how traffic flows from external clients through the LoadBalancer to the Nginx pods.
+  Learn the basics of deploying and managing stateless applications in Kubernetes.
+  Use this as a foundation to explore more advanced Kubernetes concepts like autoscaling, rolling updates, and integration with service meshes.
+  In summary, this design sets up a highly available Nginx web server with external access and load balancing, making it a fundamental example of how to deploy and expose applications using Kubernetes.
 patternCaveats: |
   1. LoadBalancer Requirement: Needs a cloud provider or environment that supports LoadBalancer services; otherwise, external access might not work.
-2. Namespace Conflicts: Ensure the nginx-namespace is properly managed to avoid conflicts with existing resources.
-3. Resource Availability: The cluster must have enough resources to run the two Nginx replicas.
-Default Nginx Config: Uses basic Nginx settings; not suitable for production without customization.
+  2. Namespace Conflicts: Ensure the nginx-namespace is properly managed to avoid conflicts with existing resources.
+  3. Resource Availability: The cluster must have enough resources to run the two Nginx replicas.
+  Default Nginx Config: Uses basic Nginx settings; not suitable for production without customization.
 permalink: catalog/deployment/nginx-k8s-deployment-29b94780-865c-460b-b852-cc5c31730561.html
 URL: 'https://raw.githubusercontent.com/meshery/meshery.io/master/catalog/29b94780-865c-460b-b852-cc5c31730561/0.0.5/design.yml'
 downloadLink: 29b94780-865c-460b-b852-cc5c31730561/design.yml


### PR DESCRIPTION
**Description**

This PR fixes #1877 the YAML parsing error in the file `29b94780-865c-460b-b852-cc5c31730561.md` located in the `_catalog/deployment` directory. The error was due to Missing Indentation.

**Notes for Reviewers**

- The YAML front matter in the affected file has been corrected with the correct indentation, resolving the parsing issue.
- The build process for the meshery.io site should no longer produce errors related to this YAML file.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

---

Feel free to adjust any details as needed before submitting!