### PR TITLE
[mesheryctl] Fall back to stable release

### DIFF
--- a/install
+++ b/install
@@ -131,12 +131,13 @@ if [ "x${MESHERY_VERSION}" = "x" ] ; then
   exit;
 fi
 
-# For patch releases, the meshery tar ball will not be generated, so fall back to last stable release
-if [[ "$MESHERY_VERSION" ==  *"patch"* ]] ; then
-    LAST_MESHERY_VERSION=`echo $MESHERY_VERSION | awk -F '-patch' '{print $1}'`
+# For patch/alpha/beta/rc releases, the meshery tar ball will not be generated, so fall back to last stable release
+if [[ "$MESHERY_VERSION" =~ .+-(patch|alpha|beta|rc) ]] ; then
+    LAST_MESHERY_VERSION=$(git ls-remote --tags https://github.com/meshery/meshery | grep -v -E 'patch|alpha|beta|rc' | tail -1 | sed -E "s/(.+)(v.+)/\2/")
     printf "Patch release %s is not supported, falling back to last stable release: %s\n\n" "$MESHERY_VERSION" "$LAST_MESHERY_VERSION"
     MESHERY_VERSION=$LAST_MESHERY_VERSION
 fi
+
 
 NAME="mesheryctl-${MESHERY_VERSION}"
 URL="https://github.com/meshery/meshery/releases/download/${MESHERY_VERSION}/mesheryctl_${MESHERY_VERSION:1}_${OSEXT}_${OSARCHITECTURE}.tar.gz"


### PR DESCRIPTION
This PR fixes:
[build-and-release-stable.yml](https://github.com/meshery/meshery/blob/master/.github/workflows/build-and-release-stable.yml) only builds tar if the tags do not contain the suffices: patch, alpha, beta, rc. However, [install] (https://github.com/meshery/meshery.io/blob/master/install) script in meshery.io only strips the patch suffix, leading to being unable to install meshery if there is no tar of the same version, for example
- Latest tag v0.8.0-alpha.1 -> no stripping suffix, latest version will be v0.8.0-alpha.1 but no tar ball to install
- Latest tags v0.8.0-patch.2 v0.8.0-patch.1 -> stripping suffix, but no v0.8.0 with tar ball
This PR uses git ls-remote to query the latest tags of meshery and exclude all the tags with suffices alpha, beta, patch, and rc 
