### PR TITLE
[UI] Fix: Remove next button and adjust dropdown to prevent icon overlap

### DIFF
--- a/_includes/view-all.html
+++ b/_includes/view-all.html
@@ -10,9 +10,6 @@
     </select>
     <input type="text" id="search" placeholder="Search..." />
   </div>
-  <div class="viewall next">
-    <button class="viewallbtn nextBtn">Next</button>
-  </div>
 </div>
 
 <script type="module">

--- a/collections/_pages/extensions.html
+++ b/collections/_pages/extensions.html
@@ -20,14 +20,16 @@ published: true
   }
   #sort {
     padding: 10px;
-    font-size: 16px;
+    width: 166px;
+    font-size: 15px;
+    outline: none;
     border: 1px solid #ddd;
     border-radius: 5px;
     background-color: #f9f9f9;
     appearance: none;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="18px" height="18px"><path d="M7 10l5 5 5-5z"/></svg>');
     background-repeat: no-repeat;
-    background-position: right 10px top 50%;
+    background-position: right 2px top 50%;
     margin-right: 10px;
     @media (max-width: 506px) {
      display: none;


### PR DESCRIPTION
**Description**

This PR fixes #1863

**Notes for Reviewers**

**Additional Fixes:**

***Description:*** Adjusted the dropdown menu to prevent the icon from overlapping the option text.

***Details:*** Modified the dropdown width and adjusted the CSS to ensure the dropdown icon no longer covers the text, improving the overall user interface.

**BEFORE**
![image](https://github.com/user-attachments/assets/e7cdf9ce-7416-4130-80db-34e835765ac2)

**AFTER**
![image](https://github.com/user-attachments/assets/f077f995-ca35-4fa2-94b5-62d95f61f2b4)



**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
