### PR TITLE
Add make clean command to the MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,9 @@ helm-repo-update:
 .PHONY: artifacthub-artifacts
 artifacthub-artifacts:
 	cd $(ARTIFACTHUB_SCRIPT_DIR); go run hub.go
+
+# Clean target to remove generated files
+.PHONY: clean
+clean:
+	rm -rf _site
+	rm -rf .jekyll-metadata

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,4 @@ artifacthub-artifacts:
 clean:
 	rm -rf _site
 	rm -rf .jekyll-metadata
+	rm -rf .jekyll-cache

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,5 @@ clean:
 	rm -rf _site
 	rm -rf .jekyll-metadata
 	rm -rf .jekyll-cache
+	docker stop meshery-io || true
+	docker rm meshery-io || true


### PR DESCRIPTION
**Description**

This PR adds a make clean command which helps to remove the generated files when the site is built.

This PR fixes #1973 

**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
