### PR TITLE
Add appropriate permissions for github workflows

### DIFF
--- a/.github/workflows/add-catalog.yml
+++ b/.github/workflows/add-catalog.yml
@@ -5,6 +5,11 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [add_catalog]
+
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   UpdateCloudNativeCatalog:
     runs-on: ubuntu-22.04

--- a/.github/workflows/delete-catalog.yml
+++ b/.github/workflows/delete-catalog.yml
@@ -2,6 +2,10 @@ name: Delete Cloud Native Catalog Items
 on:
   repository_dispatch:
     types: [delete_catalog]
+
+permissions:
+  contents: write
+
 jobs:
   UpdateCloudNativeCatalog:
     runs-on: ubuntu-22.04

--- a/.github/workflows/error-code-updater.yml
+++ b/.github/workflows/error-code-updater.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "assets/artifact-hub-pkg/**.go"
 
+permissions:
+  contents: write
+
 jobs:
   Update-error-codes:
     name: Error codes utility

--- a/.github/workflows/newcomers-alert.yml
+++ b/.github/workflows/newcomers-alert.yml
@@ -2,6 +2,10 @@ name: Newcomers Alert
 on:
   issues:
     types: [labeled]
+
+permissions:
+  issues: read
+
 jobs:
   good-first-issue-notify:
     if: github.event.label.name == 'good first issue' || github.event.label.name == 'first-timers-only' 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-22.04

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,5 +1,9 @@
 name: Slack Notify on Star
 on: watch
+
+permissions:
+  contents: read
+
 jobs:
   star-notify:
     name: Notify Slack on star

--- a/.github/workflows/updateDiscussons.yml
+++ b/.github/workflows/updateDiscussons.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * *' #runs every day at midnight
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
**Description**

This PR fixes #2103

**Notes for Reviewers**
I added appropriate permission for some workflows that did not have any permission attach to it. Like for:
- add-catalog, delete-catalog, error-code-update, update-discussion: For checkout and commit changes ``` contents: write```
- newcomers-alert: For reading only issue ``` issues: read```
- release-drafter: For drafting release ``` pull-requests: write```, ``` contents: read```
- slack: For reading star count ``` contents: read```

Took reference from this pr:  https://github.com/meshery/meshery/pull/14168




**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
