### PR TITLE
fix: logo not visible in dark mode (#2164)

### DIFF
--- a/_includes/features.html
+++ b/_includes/features.html
@@ -240,8 +240,8 @@
     <div class="container flex">
         <div class="text ">
             <div style="display: flex;">
-                <img src="/assets/images/patterns/service-mesh-patterns-side.svg" data-logo-for-light="/assets/images/patterns/service-mesh-patterns-side-white.png"
-                    data-logo-for-dark="{{ features.logoDarkMode }}" id="logo-dark-light"
+                <img src="/assets/images/patterns/service-mesh-patterns-side.svg" data-logo-for-light="/assets/images/patterns/service-mesh-patterns-side.svg"
+                    data-logo-for-dark="/assets/images/patterns/service-mesh-patterns-side-white.png" id="logo-dark-light"
                     alt="Cloud native design patterns" style="height: 4rem;" loading="lazy" />
                 <span>
             </div>


### PR DESCRIPTION
**Description**

This PR fixes #2164

The "Cloud Native Design Patterns" logo was not visible in dark mode across multiple browsers (Chrome, Edge, Firefox). This fix ensures that the logo remains clearly visible regardless of the theme applied.

**Notes for Reviewers**

- Tested the fix on Chrome, Edge, and Firefox on Windows 11.
- Verified the logo displays correctly in both light and dark modes.

[Screencast from 2025-05-20 22-58-09.webm](https://github.com/user-attachments/assets/e2d0f2f7-85be-47a8-b55b-ffa51455b0dc)

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

> If not yet signed, I’ll amend the commit with --signoff and force push.  should i add a demo video


