### PR TITLE
sync catalog directories to docs

### DIFF
--- a/.github/workflows/add-catalog.yml
+++ b/.github/workflows/add-catalog.yml
@@ -144,13 +144,10 @@ jobs:
           done
           rm temp.json
 
-      - name: copy catalog directory to docs
+      - name: sync catalog directories to docs
         run: |
-          mkdir -p meshery/docs/_catalog
-          cp -R meshery.io/collections/_catalog/* meshery/docs/_catalog/
-
-          mkdir -p meshery/docs/catalog
-          cp -R meshery.io/catalog/* meshery/docs/catalog/
+          rsync -av --delete meshery.io/collections/_catalog/ meshery/docs/_catalog/
+          rsync -av --delete meshery.io/catalog/ meshery/docs/catalog/
 
       - name: Pull latest changes from meshery/meshery
         run: |


### PR DESCRIPTION
**Description**
- current `cp -R` commands do not delete catalog files in the destination (`meshery/docs/_catalog`) that are no longer present in the source (`meshery.io/collections/_catalog`  - reason, unpublished / deletion) leading to stale content.

This PR uses `rsync` to ensure that the destination directories are an exact mirror of the source directories.


**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
