### PR TITLE
feat: sort based on requirements

### DIFF
--- a/collections/_pages/extensions.html
+++ b/collections/_pages/extensions.html
@@ -66,7 +66,8 @@ published: true
   {% assign filtered = site.extensions | where: "type", type %}
   {% assign extensions_by_type = extensions_by_type | concat: filtered %}
 {% endfor %}
-{% assign extensions = extensions_by_type %}
+{% assign remaining_extensions = site.extensions | where_exp: "item", "ordered_types contains item.type == false" | sort: "type" %}
+{% assign extensions = extensions_by_type | concat: remaining_extensions %}
 
 
 <div class="section-container">

--- a/collections/_pages/extensions.html
+++ b/collections/_pages/extensions.html
@@ -66,7 +66,13 @@ published: true
   {% assign filtered = site.extensions | where: "type", type %}
   {% assign extensions_by_type = extensions_by_type | concat: filtered %}
 {% endfor %}
-{% assign remaining_extensions = site.extensions | where_exp: "item", "ordered_types contains item.type == false" | sort: "type" %}
+{% assign remaining_extensions = "" | split: "" %}
+{% for ext in site.extensions %}
+  {% unless ordered_types contains ext.type %}
+    {% assign remaining_extensions = remaining_extensions | push: ext %}
+  {% endunless %}
+{% endfor %}
+
 {% assign extensions = extensions_by_type | concat: remaining_extensions %}
 
 

--- a/collections/_pages/extensions.html
+++ b/collections/_pages/extensions.html
@@ -60,7 +60,14 @@ published: true
   }
 </style>
 
-{% assign extensions = site.extensions | sort: 'type' %}
+{% assign ordered_types = "GitOps,Configuration,Collaboration,Lifecycle" | split: "," %}
+{% assign extensions_by_type = "" | split: "" %}
+{% for type in ordered_types %}
+  {% assign filtered = site.extensions | where: "type", type %}
+  {% assign extensions_by_type = extensions_by_type | concat: filtered %}
+{% endfor %}
+{% assign extensions = extensions_by_type %}
+
 
 <div class="section-container">
   {% include view-all.html %} {% include extensions/card-modal.html %}


### PR DESCRIPTION
**Description**

This PR fixes #2273

**Notes for Reviewers**
Ordering requirement:  GitOps first, then Configuration, then Collaboration, then Lifecycle.

The changes handle the ordering requirement, while ensuring no extensions (that might be added in future and with different category) are missed.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
