### PR TITLE
Highlight KubeCon NA 2024 in talks-and-presentations modal

### DIFF
--- a/collections/_pages/talks-and-presentations.html
+++ b/collections/_pages/talks-and-presentations.html
@@ -42,11 +42,11 @@ redirect_from: talks-and-presentations
 }
 
 .modal-header {
-    display: flex;
-    gap: 2rem;
-    justify-content: center;
-    align-items: center;
-  }
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  align-items: center;
+}
 
 .button-para{
   margin-bottom: 1rem;
@@ -221,26 +221,28 @@ td{
 <section class="event">
   <div class="container flex">
     <div class="text talks-description" >
-      <h2>CNCF On-Demand Webinar: <strong>Meshery - The Cloud Native Manager</strong></h2>
-      <p> This webinar introduces Meshery, the self-service engineering platform,that enables collaborative design and operation of cloud native infrastructure.</p>
+      
+      
+      <h2>KubeCon + CloudNativeCon NA 2024:<strong>Meshery: Visualizing Kubernetes Resource Relationships with Meshery</strong></h2>
+      <p>This talk covers how Meshery and its extensions empower you to navigate cloud native infrastructure in complex environments. It explored the human-computer interaction (HCI) principles that underpin MeshMap’s intuitive visualization of Kubernetes resources and highlighted the various interconnections and relationships with other CNCF projects’ resources.</p>
         <br>
         <div class="button-para">
-          <button class="link open-modal-btn">Find video and slides here</button>  
+          <button class="link open-modal-btn">Find video here</button>  
         </div>
 
         <div id="open-modal" class="modal-window">
           <div class ="modal-content">
             <div class="modal-header">
-              <h1>An Introduction to Meshery (CNCF Webinar-on-Demand)</h1>
+              <h1>Visualizing Kubernetes Resource Relationships</h1>
               <button class="modal-close close">&times;</button>
             </div>
             <div>
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/DZitzsSrF4E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/xJ9RH0AE7zE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
-            <div>
+            <!-- <div>
               <div><small>Slides</small></div>
               <a href="https://docs.google.com/presentation/d/1YxeERLarsh60ItrgT29KzlNQEjkRnw5WDnnwy2uUe1Y/edit?usp=sharing" target="_blank">CNCF Webinar - The Cloud Native Management Plane</a>
-            </div>
+            </div> -->
           </div>
         </div>
       

--- a/collections/_pages/talks-and-presentations.html
+++ b/collections/_pages/talks-and-presentations.html
@@ -240,7 +240,7 @@ td{
             </div>
             <div>
               <div><small>Slides</small></div>
-              <a href="https://docs.google.com/presentation/d/1kYZNJjZhL6FIsECVhAGEWn7_6gLe2guQCqUxpPz7U84/edit?usp=sharing" target="_blank">KubeCon + CloudNativeCon NA 2024</a>
+              <a href="https://docs.google.com/presentation/d/1kYZNJjZhL6FIsECVhAGEWn7_6gLe2guQCqUxpPz7U84/edit?usp=sharing" target="_blank">Meshery in Five Minutes</a>
             </div>
           </div>
         </div>

--- a/collections/_pages/talks-and-presentations.html
+++ b/collections/_pages/talks-and-presentations.html
@@ -43,7 +43,6 @@ redirect_from: talks-and-presentations
 
 .modal-header {
   display: flex;
-  gap: 2rem;
   justify-content: center;
   align-items: center;
 }
@@ -227,7 +226,7 @@ td{
       <p>This talk covers how Meshery and its extensions empower you to navigate cloud native infrastructure in complex environments. It explored the human-computer interaction (HCI) principles that underpin MeshMap’s intuitive visualization of Kubernetes resources and highlighted the various interconnections and relationships with other CNCF projects’ resources.</p>
         <br>
         <div class="button-para">
-          <button class="link open-modal-btn">Find video here</button>  
+          <button class="link open-modal-btn">Find video and slides here</button>  
         </div>
 
         <div id="open-modal" class="modal-window">
@@ -239,10 +238,10 @@ td{
             <div>
                 <iframe width="560" height="315" src="https://www.youtube.com/embed/xJ9RH0AE7zE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
-            <!-- <div>
+            <div>
               <div><small>Slides</small></div>
-              <a href="https://docs.google.com/presentation/d/1YxeERLarsh60ItrgT29KzlNQEjkRnw5WDnnwy2uUe1Y/edit?usp=sharing" target="_blank">CNCF Webinar - The Cloud Native Management Plane</a>
-            </div> -->
+              <a href="" target="_blank">KubeCon + CloudNativeCon NA 2024</a>
+            </div>
           </div>
         </div>
       

--- a/collections/_pages/talks-and-presentations.html
+++ b/collections/_pages/talks-and-presentations.html
@@ -240,7 +240,7 @@ td{
             </div>
             <div>
               <div><small>Slides</small></div>
-              <a href="" target="_blank">KubeCon + CloudNativeCon NA 2024</a>
+              <a href="https://docs.google.com/presentation/d/1kYZNJjZhL6FIsECVhAGEWn7_6gLe2guQCqUxpPz7U84/edit?usp=sharing" target="_blank">KubeCon + CloudNativeCon NA 2024</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Description**

This PR fixes #2278 by updating the /talks-and-presentations section of the Meshery.io site to highlight the KubeCon NA 2024 presentation.

**Notes for Reviewers**

Please verify that the updated modal correctly showcases the KubeCon NA 2024 talk with the new embedded video and heading.

**Current View**

![Screenshot 2025-07-04 at 7 21 07 PM](https://github.com/user-attachments/assets/744786d1-ba2e-41e3-8aad-b2526c9673a0)
![Screenshot 2025-07-04 at 7 21 54 PM](https://github.com/user-attachments/assets/aab2e51b-8447-4520-b936-668b9e883fa5)

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

