### PR TITLE
Created Github Organization Membership page, completed #2197

### DIFF
--- a/collections/_handbook/instructions.md
+++ b/collections/_handbook/instructions.md
@@ -1,4 +1,100 @@
 ---
 title: "GitHub Organization Membership"
-description:  "Consistent contributors may receive invitations to Meshery GitHub orgs."
+description: "Consistent contributors may receive invitations to Meshery GitHub orgs.  "
 ---
+
+<style>
+  body {
+    color: white;
+    background-color: #000;
+    font-size: 18px;
+    line-height: 1.8;
+    padding-bottom: 2rem;
+  }
+
+  h1, h2 {
+    font-weight: 700;
+    color: #00C2A8;
+    margin-top: 2.5rem;
+    margin-bottom: 1.2rem;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+  }
+
+  h2 {
+    font-size: 2rem;
+  }
+
+  ul, ol {
+    padding-left: 2rem;
+    font-size: 18px;
+  }
+
+  p {
+    margin-bottom: 1.2rem;
+    font-size: 18px;
+  }
+
+  code {
+    background-color: #1a1a1a;
+    padding: 0.3rem 0.5rem;
+    border-radius: 4px;
+    font-size: 90%;
+    color: #eee;
+    border: none;
+  }
+
+
+
+  blockquote {
+    border-left: 4px solid #00C2A8;
+    padding-left: 1rem;
+    color: #ccc;
+    margin: 1.5rem 0;
+    font-style: italic;
+  }
+</style>
+
+## Membership Requirements
+
+Membership to the GitHub organizations is a significant milestone for contributors who
+have shown persistent commitment and dedication to Meshery projects. It is not solely about
+writing code but rather the consistency of engagement and alignment of mentality.
+
+Contributors who may be invited typically:
+
+- Have been actively involved in the community for several weeks
+- Make regular updates to projects
+- Help other community members
+- Attend development meetings
+- Demonstrate a willingness to learn and share knowledge
+- Show a genuine desire to improve themselves, others, and the projects
+
+## Invitation Process
+
+Depending on the number and quality of contributions made across the five GitHub organizations of Meshery, contributors can receive an invitation to any or all of these orgs. The process involves:
+
+1. Sending a group DM
+2. Executing Slack slash command in `#community-management`
+
+## Group Message for Invitations
+
+When you identify a worthy contributor, send a message in a group DM that includes the individual and other maintainers/appropriate members.
+
+> Refer to the **Community Managers' docs** to see some examples.
+
+## Sending the GitHub Invitation
+
+To send the invitation to join the GitHub organization, use the following slash command in the `#community-management` channel:
+
+`/invite-github [email address] [organization name]`
+
+Where [organization name] should be:
+
+- meshery – to invite the email address to Meshery GitHub organization under the "contributors" team
+
+For example:
+
+`/invite-github contributor@example.com meshery.io`


### PR DESCRIPTION
**Description**

This PR fixes #2197 
This PR introduces a new documentation page titled "GitHub Organization Membership" to the Meshery website under the /community section.

**Notes for Reviewers**
- Describes the significance of becoming a member of Layer5 and Meshery GitHub organizations.
- Outlines the membership criteria, including consistent contribution and community involvement.
- Provides a clear invitation process, including example Slack commands.
- Uses custom HTML styling to match the Meshery site’s visual aesthetic (dark theme, teal headers, readable layout).

Includes detailed usage instructions for the /invite-github command with real examples.


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
