### PR TITLE
Fix button wrapper mobile responsiveness

### DIFF
--- a/assets/css/community.css
+++ b/assets/css/community.css
@@ -90,6 +90,21 @@
     cursor: pointer;
   }
 
+  /* Optimized button styles for forum and MeshMates buttons */
+  .button-wrapper .highlight {
+    min-width: 120px;
+    max-width: fit-content;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    padding: 10px 20px !important;
+    box-sizing: border-box;
+    width: auto;
+    border-radius: 4px;
+  }
+
   @media (max-width: 600px) {
 
     .hero {
@@ -423,8 +438,9 @@
     }
 
     .button-wrapper a {
-      width: 100%;
-      max-width: 280px;
+      width: auto;
+      min-width: 120px;
+      max-width: 200px;
       text-align: center;
     }
   }

--- a/assets/css/community.css
+++ b/assets/css/community.css
@@ -99,10 +99,19 @@
     overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;
-    padding: 10px 20px !important;
     box-sizing: border-box;
     width: auto;
     border-radius: 4px;
+  }
+  
+  /* Increased specificity for padding instead of using !important */
+  .button-wrapper a.highlight {
+    padding: 10px 15px;
+  }
+  
+  /* Specific styling for longer button text */
+  .button-wrapper a[href="https://discuss.layer5.io"] {
+    min-width: 180px;
   }
 
   @media (max-width: 600px) {

--- a/assets/css/community.css
+++ b/assets/css/community.css
@@ -403,6 +403,41 @@
 
   .button-wrapper {
     margin-top: 50px;
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .button-wrapper a {
+    display: inline-block;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  /* Make buttons responsive on mobile */
+  @media screen and (max-width: 768px) {
+    .button-wrapper {
+      flex-direction: column;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .button-wrapper a {
+      width: 100%;
+      max-width: 280px;
+      text-align: center;
+    }
+  }
+
+  @media screen and (max-width: 480px) {
+    .button-wrapper {
+      gap: 0.5rem;
+    }
+
+    .button-wrapper a {
+      font-size: 0.9rem;
+      padding: 8px !important;
+    }
   }
 
   .handbook-button {

--- a/assets/css/community.css
+++ b/assets/css/community.css
@@ -434,9 +434,10 @@
       gap: 0.5rem;
     }
 
-    .button-wrapper a {
+    .button-wrapper a.highlight,
+    .button-wrapper a.import-secondary {
       font-size: 0.9rem;
-      padding: 8px !important;
+      padding: 8px;
     }
   }
 


### PR DESCRIPTION
**Description**
Resolved a UI issue on the Meshery Community page where the "Layer5 Discussion Forum" and "Add your forum" buttons overlapped in mobile view (≤375px).

This PR fixes https://github.com/meshery/meshery.io/issues/2314

**Notes for Reviewers**
<li>Please test the page in responsive mode (e.g., 375px width) using browser dev tools to verify the layout.<br>


(Broken layout at 375px width)

<img width="720" height="937" alt="Before Fix" src="https://github.com/user-attachments/assets/f30694c4-5d05-4bc3-9771-ec8079ba5539" />

(Fixed layout - responsive and readable)

<img width="868" height="985" alt="After Fix" src="https://github.com/user-attachments/assets/fb3c6267-07d1-4258-bad9-0af2ef3be87e" />

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
