### PR TITLE
Fix: Add null checks to prevent 'classList' of null error on all pagesAdd null checks

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -101,7 +101,9 @@
           // $('.sitewide-banner').animate({top: 0});
           const banner = document.querySelector(".sitewide-banner");
           setTimeout(function() {
+            if (banner) {
             banner.classList.remove("hidden");
+            }
             
           }, 0); // Add a delay of 1 second before showing the banner
         });


### PR DESCRIPTION
**Description**
Added a null check before accessing classList to prevent the "Cannot read properties of null (reading 'classList')" error occurring on all pages.
This PR fixes #2317 

**Notes for Reviewers**
This change only adds a simple null check to ensure the element exists before accessing classList. No other functionality is affected.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->