### PR TITLE
fix: ensure video controls visible on large screens

### DIFF
--- a/_includes/catalog-help-modal.html
+++ b/_includes/catalog-help-modal.html
@@ -1,23 +1,23 @@
 <style>
-    .help-modal {
-  display: none; /* Hidden by default */
-  position: fixed; /* Stay in place */
-  z-index: 200; /* Sit on top */
-  left: 0;
-  top: 0;
-  width: 100%; /* Full width */
-  height: 100%; /* Full height */
-  overflow: auto; /* Enable scroll if needed */
-  background-color: rgb(0,0,0); /* Fallback color */
-  background-color: rgba(0,0,0,0.75); /* Black w/ opacity */
-}
+  .help-modal {
+    display: none; /* Hidden by default */
+    position: fixed; /* Stay in place */
+    z-index: 200; /* Sit on top */
+    inset: 0; /* top:0; right:0; bottom:0; left:0 */
+    width: 100vw; /* Full width */
+    height: 100vh; /* Full height */
+    padding: 2rem; /* Breathing room around content */
+    box-sizing: border-box;
+    display: flex; /* Center modal content */
+    align-items: center;
+    justify-content: center;
+    overflow: hidden; /* Contain scroll within content */
+    background-color: rgba(0,0,0,0.75); /* Backdrop */
+  }
 
-::-webkit-scrollbar {
-    display: "none";
-  }
-  .help-modal::-webkit-scrollbar {
-    display: none;
-  }
+  /* Hide scrollbars for WebKit if any appear */
+  ::-webkit-scrollbar { display: none; }
+  .help-modal::-webkit-scrollbar { display: none; }
 
 /* Style the tab */
 .tab {
@@ -57,12 +57,17 @@
 /* Modal Content/Box */
 .help-modal-content {
   background-color: #fefefe;
-  margin: 5% auto; /* 5% from the top and centered */
   border: 1px solid #888;
-  width: 60%; /* Could be more or less, depending on screen size */
-  @media (max-width: 768px) {
-    margin: 25% auto;
+  width: min(960px, 90vw);
+  max-height: 90vh;            /* Keep content within viewport */
+  overflow-y: auto;            /* Scroll inside content if needed */
+  border-radius: 8px;
+}
+
+@media (max-width: 768px) {
+  .help-modal-content {
     width: 85%; /* Change width to 85% */
+    max-height: 90vh;
   }
 }
 
@@ -102,7 +107,7 @@
             <!-- <a href="{{ site.baseurl }}/assets/images/screens/pattern-import.mp4"
 				data-fancybox="images" data-caption="Import your patterns"> -->
         <div style="text-align: center;">
-          <video width="100%" preload="metadata" controls>
+          <video style="width: 100%; height: auto; max-height: 70vh;" preload="metadata" controls>
             <source src="{{ site.baseurl }}/assets/images/screens/pattern-import.mp4#t=0.01" type="video/mp4">
           </video>
 				<!-- <iframe width="98%" height="540" preload="metadata" src="{{ site.baseurl }}/assets/images/screens/pattern-import.mp4#t=0.01" alt="Import your patterns" 

--- a/_sass/modal.scss
+++ b/_sass/modal.scss
@@ -2,35 +2,41 @@
 
 /* modal background */
 .modal-video {
-    display: none;                  /* Hidden by default */
+    display: none;                     /* Hidden by default */
     position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    top: 0;                            /* Cover full viewport */
+    left: 0;
+    transform: none;                   /* Avoid shifting overlay off-screen */
     z-index: 200;                      /* Sit on top */
-    width: 100%;                      /* Full width */
-    height: 100%;   
-    overflow: auto;
-    overflow-x: hidden;                   /* Enable scroll if needed */
-    background-color: rgb(0,0,0);   /* Fallback color */
-    background-color: rgba(0,0,0,0.7); /* Black w/ opacity */
-    transition: all 0.3s;
+    width: 100vw;                      /* Full width */
+    height: 100vh;                     /* Full height */
+    padding: 2rem;                     /* Breathing room around content */
+    box-sizing: border-box;
+    display: flex;                     /* Center modal content */
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;                  /* Contain scroll inside content */
+    background-color: rgba(0,0,0,0.7); /* Backdrop */
+    transition: opacity 0.2s ease-in-out;
  
     /* modal content */
     .modal-content-video {
         display: flex;
-        flex-flow: row wrap;
-        justify-content: space-between;
+        flex-direction: column;
+        row-gap: 0.75rem;
         background-color: $coolgray;
         color: white;
-        width: 80%;
-        margin-top: 10%;
-        padding: 0rem 1.5rem 1.5rem 1.5rem;
-        border-radius: 1%;
-    & h3 { 
-        font-size: 2rem !important;
-        color: var(--color-white);
-    }
+        width: min(960px, 90vw);
+        max-height: 90vh;             /* Keep content within viewport */
+        margin: 0;                    /* Avoid pushing content out of view */
+        padding: 1rem 1.5rem 1.5rem 1.5rem;
+        border-radius: 8px;
+        overflow-y: auto;             /* Scroll inside modal content if needed */
+
+        & h3 { 
+            font-size: 2rem !important;
+            color: var(--color-white);
+        }
     }
  
     /* close button */
@@ -43,6 +49,14 @@
         text-decoration: none;
         cursor: pointer;
         color: $lightgreen;
+    }
+
+    /* Ensure video scales and controls remain visible */
+    video#video {
+        display: block;
+        width: 100%;
+        height: auto;                 /* Preserve aspect ratio */
+        max-height: 70vh;             /* Leave space for title/close */
     }
 }
   


### PR DESCRIPTION

**Summary**
This PR fixes an issue where video controls were not visible on large screens in the catalog “Help” modal and the generic video modal. The modals are now centered using flexbox, span the full viewport, constrain their height to fit the screen, and scroll internally when content overflows. The video scales responsively so native controls remain visible and accessible on all screen sizes.

**Resolves:** #1776

---

**What Changed**

* **Modal overlay layout**

  * Centered overlay using flexbox
  * Full-viewport dimensions (`100vw` x `100vh`) with backdrop
  * Internal scrolling within modal content (page behind does not scroll)

* **Video sizing**

  * Responsive width (`100%`) with auto height
  * Max-height constraint to prevent control clipping

---

**Files Touched**

* `modal.scss`
* `catalog-help-modal.html`

---

**How to Test**

1. **Run locally**

   ```bash
   docker run --name meshery-io-dev --rm -p 4000:4000 -v "$PWD":/srv/app -w /srv/app ruby:3.2.2 \
   bash -lc "apt-get update && apt-get install -y build-essential git libffi-dev libxml2-dev libxslt1-dev zlib1g-dev \
   && gem install bundler:2.6.0 && bundle install && bundle exec jekyll serve --drafts --livereload --host 0.0.0.0 \
   --config _config_dev.yml"
   ```
2. Open `http://localhost:4000/catalog`
3. Open the **Help** modal and play the video
4. Click “Publish your own best practices”
5. In the Meshery UI tab, play the video and confirm controls are visible
6. Verify across sizes: 1366×768, 1920×1080, 2560×1440
7. Mobile check (\~375px width): video scales; controls remain accessible

---

**Expected Behavior**

* Modal is centered, page behind doesn’t scroll
* Video controls visible and reachable
* Internal scrolling when content is tall (no double scrollbars)

---

**Checklist**

* [x] Fix limited to video/help modals
* [x] Manual test locally
* [x] DCO sign-off in commits

---

**Notes for Reviewers**
If the video doesn’t play, try opening it directly at `pattern-import.mp4` or remove `#t=0.01` from the source. Codec issues can be confirmed via DevTools (`NotSupportedError`).

---

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
