### PR TITLE
Fix broken "Visit" link in GitHub Action Kanvas Snapshot (404 error)

### DIFF
--- a/collections/_extensions/github-action-meshery-snapshot.md
+++ b/collections/_extensions/github-action-meshery-snapshot.md
@@ -19,6 +19,6 @@ extensionCaveats: |
   - See your deployment before you merge.
   - Utilize Kanvas Snapshot when you need to automate your software development process using GitHub Actions.
   - Customize snapshot workflow triggers to run based on specific GitHub activities, such as creating a pull request, pushing code, or releasing a new version.
-URL: 'https://github.com/marketplace/actions/meshmap-snapshot'
+URL: 'https://github.com/marketplace/actions/kanvas-snapshot'
 docsURL: 'https://docs.meshery.io/extensions/kanvas-snapshot'
 ---


### PR DESCRIPTION
**Description**

This PR fixes #2329
This PR updates the Visit link in the   GitHub Action Kanvas Snapshot extension to point to the correct Kanvas URL.
Previously, the link redirected to the old MeshMap URL, resulting in a 404 Not Found error.
With this update, clicking Visit will now navigate to the correct Kanvas page.

[Screencast from 2025-08-12 20-32-21.webm](https://github.com/user-attachments/assets/03e0af82-4ef1-463a-8160-bb02ec163a72)


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
