### PR TITLE
Calender Newcomers map broken link

### DIFF
--- a/_includes/newcomers-map.html
+++ b/_includes/newcomers-map.html
@@ -385,7 +385,7 @@
     </a>
     <a
       class="highlight"
-      href="https://meshery.io/community/handbook"
+      href="https://docs.meshery.io/project/contributing"
       target="_blank"
       rel="noreferrer"
     >
@@ -423,7 +423,7 @@
     ></path>
     <a
       class="highlight"
-      href="https://meshery.io/community/handbook/repository-overview"
+      href="https://github.com/meshery"
       target="_self"
     >
       <path


### PR DESCRIPTION
**Description**

This PR fixes the broken links on the Newcomercs map.
Previously, some links on the map were not functioning as expected. All affected links have now been updated or corrected, and are working properly.


**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
