### PR TITLE
Fix: Make model catalog buttons responsive on smaller screens

### DIFF
--- a/_sass/catalog.scss
+++ b/_sass/catalog.scss
@@ -1019,6 +1019,7 @@ label {
     flex-direction: row;
     gap: 1rem;
     // padding-bottom: 2rem;
+    flex-wrap: wrap;
     width: 100%;
     justify-content: center;
   }


### PR DESCRIPTION
### Summary
This PR fixes a **major mobile usability issue** on the  model page where the three action buttons were being cut off on small screens.  

### Changes
- Updated `catalog.scss` to use `flex-wrap` on the button container for smaller screens.
- Ensures all buttons are visible and easily accessible on mobile.

### Impact
- Improves mobile user experience for anyone accessing the model page.
- Fixes a blocker for users trying to interact with the catalog on mobile devices.

### Hacktoberfest 2025
This contribution is part of **Hacktoberfest 2025**.

Fixes #2357 
