### PR TITLE
fix: removed  the coming soon status and added the real meshsync logo

### DIFF
--- a/collections/_extensions/kubectl-meshsync-snapshot.md
+++ b/collections/_extensions/kubectl-meshsync-snapshot.md
@@ -8,7 +8,7 @@ type: Configuration
 compatibility: 
   - kubernetes
   - kanvas
-extensionId: 2d54f372-10e5-4c4e-8d23-b9c35c68ce96
+#extensionId: 2d54f372-10e5-4c4e-8d23-b9c35c68ce96
 logo: /assets/images/logos/meshsync.svg
 whiteImage: /assets/images/logos/meshsync.svg
 colorImage: /assets/images/logos/meshsync-white.svg


### PR DESCRIPTION
**Description**

This PR fixes #2397 by removing the `coming-soon` status and adding the real **MeshSync** logo for the **Kubectl Plugin for MeshSync Snapshot** extension entry.  
This update ensures that the actual MeshSync logo and details are displayed correctly on the [Extensions page](https://meshery.io/extensions).

**Notes for Reviewers**

- Removed `status: coming-soon` from `collections/_extensions/kubectl-plugin-for-meshsync-snapshot.md`.
- Added the real MeshSync logo image reference.
- Verified the change locally to ensure correct display.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**  
- [ ] Yes, I signed my commits.
