### PR TITLE
fix(mesheryctl): update link that is not clickable

### DIFF
--- a/collections/_posts/2025/10/30/2025-10-30-mesehryctl-e2e-test-introduction.md
+++ b/collections/_posts/2025/10/30/2025-10-30-mesehryctl-e2e-test-introduction.md
@@ -24,9 +24,7 @@ Meshery CLI is written in Golang built on the Cobra framework and interacts with
 
 ## How to create a test
 
-Before starting, be sure you read the contributing guide that will provide you the requirements and the implementation standards.
-
-- **Guide:** https://docs.meshery.io/project/contributing/contributing-cli-tests
+Before starting, be sure you read the contributing guide that will provide you the requirements and the implementation standards [here](https://docs.meshery.io/project/contributing/contributing-cli-tests).
 
 ### Scenario
 


### PR DESCRIPTION
**Description**

This PR fixes link not clickable in post

<img width="774" height="165" alt="image" src="https://github.com/user-attachments/assets/dde62b69-77c6-4148-a7fc-470b54a54efc" />


**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
