### PR TITLE
Enable no-duplicate-categories in `.github/release-drafter.yml`

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
+no-duplicate-categories: true
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
**Description**
As mentioned in issue #2451, release notes were showing PRs multiple times when PRs had labels matching different categories.  
This PR enables `no-duplicate-categories: true` in `.github/release-drafter.yml` to ensure each PR appears only once.

**Fixes**
- Fixes #2451

**Notes for Reviewers**
This PR fixes [Release Drafter] Prevent duplicate PR entries in release notes #2451

**Signed commits**
- [x] Yes, I signed my commits.
