### PR TITLE
Fix: community redirects and missing dev redirect plugin

### DIFF
--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -34,7 +34,6 @@ plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-feed
-  - jekyll-redirect-from
   - octopress-paginate
 
 timezone: Etc/UTC


### PR DESCRIPTION
**Description**
1. Ensures the Community page is reachable with and without a trailing slash in production, matching local behavior.
2. In newcomers map the community link was hardcoded so fixed that
3. In development config file redirect from plugin was missing so added that

This PR fixes #2523 
**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
5. Build and test your changes before submitting a PR. 
6. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
