### PR TITLE
Fix: Multiple dropdowns remain open simultaneously in navbar

### DIFF
--- a/js/stellarnav.js
+++ b/js/stellarnav.js
@@ -228,8 +228,34 @@
 			function navbarExpand(e) {
 				if(e.type == 'click' || e.key == "Enter" || e.code == "Space") {
 					e.preventDefault();
-					$(this).parent('li').children('ul').stop(true, true).slideToggle(settings.openingSpeed);
-					$(this).parent('li').toggleClass('open');
+					var $currentLi = $(this).parent('li');
+					var $currentUl = $currentLi.children('ul');
+					var isCurrentlyOpen = $currentLi.hasClass('open');
+
+					// Close all other open dropdowns at the same level (accordion behavior)
+					$currentLi.siblings('li.open').each(function() {
+						$(this).children('ul').stop(true, true).slideUp(settings.openingSpeed);
+						$(this).removeClass('open');
+						// Also close any nested open dropdowns
+						$(this).find('li.open').each(function() {
+							$(this).children('ul').stop(true, true).slideUp(settings.openingSpeed);
+							$(this).removeClass('open');
+						});
+					});
+
+					// Toggle the current dropdown
+					if (isCurrentlyOpen) {
+						$currentUl.stop(true, true).slideUp(settings.openingSpeed);
+						$currentLi.removeClass('open');
+						// Close any nested open dropdowns
+						$currentLi.find('li.open').each(function() {
+							$(this).children('ul').stop(true, true).slideUp(settings.openingSpeed);
+							$(this).removeClass('open');
+						});
+					} else {
+						$currentUl.stop(true, true).slideDown(settings.openingSpeed);
+						$currentLi.addClass('open');
+					}
 				}
 			}
 


### PR DESCRIPTION
**Description**

This PR fixes #2530 

**Notes for Reviewers**
- Before: Multiple dropdowns could remain open simultaneously in the navbar (as mentioned in issue #2530).
- After: With this solution, only one dropdown can be open at a time.

Video after solution:

https://github.com/user-attachments/assets/50338579-6428-4c9f-8d9c-bb0462178bd6




**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
