### PR TITLE
[Blog] Fix list rendering in "Try It Yourself" section of Workspaces post

### DIFF
--- a/collections/_posts/2026/02/16/2026-02-16-meshery-workspaces-enabling-cross-team-collaboration.md
+++ b/collections/_posts/2026/02/16/2026-02-16-meshery-workspaces-enabling-cross-team-collaboration.md
@@ -132,25 +132,18 @@ Workspaces integrate seamlessly with GitOps workflows:
 Ready to experience the power of Workspaces? Here's a hands-on challenge:
 
 1. **Sign up for Meshery Cloud** (free tier available) or [install Meshery locally](https://docs.meshery.io/installation)
-
 2. **Navigate to the Catalog** at [meshery.io/catalog](https://meshery.io/catalog)
-
 3. **Find a design that interests you**, such as:
    - [Kubernetes Observability Stack](https://meshery.io/catalog?search=observability)
    - [Istio Service Mesh Deployment](https://meshery.io/catalog?search=istio)
    - [NGINX Ingress with Rate Limiting](https://meshery.io/catalog?search=nginx)
-
 4. **Click "Clone to Workspace"** - this imports the design into your personal Workspace
-
 5. **Open the Visual Designer** and explore the topology:
    - See how components are connected
    - Adjust configurations to match your environment
    - Add or remove resources as needed
-
 6. **Connect your Kubernetes cluster** (if you haven't already)
-
 7. **Deploy the design** to your environment with a single click
-
 8. **Monitor the deployment** through Meshery's built-in observability features
 
 Within minutes, you'll have a production-ready infrastructure pattern running in your cluster, customized to your needs. That's the power of Workspaces and the Catalog working together.


### PR DESCRIPTION
**Description**
Fixes formatting in the "Try It Yourself" section of the Meshery Workspaces blog post.
 
 
 **Before**
 
<img width="829" height="743" alt="image" src="https://github.com/user-attachments/assets/900079b5-0c15-4ef0-ac85-7b3490f29932" />

 
 **After**
 
<img width="1091" height="712" alt="image" src="https://github.com/user-attachments/assets/6fea7287-a7b1-4c18-8efb-2204d33a7b7c" />


**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
