### PR TITLE
website: update terminology to cloud-native and reorder features

### DIFF
--- a/_includes/features.html
+++ b/_includes/features.html
@@ -156,22 +156,26 @@
 
 <section>
     <div class="container flex">
-        <div class="text ">
+        <div class="text">
             <div style="display: flex;">
-                <img src="/assets/images/patterns/cloud-native-patterns-side-white.png" data-logo-for-light="/assets/images/patterns/cloud-native-patterns-side.svg"
-    data-logo-for-dark="/assets/images/patterns/cloud-native-patterns-side-white.png" id="logo-dark-light"
-    alt="Cloud native design patterns" style="height: 4rem;" loading="lazy" />
-                <span>
+                <img src="/assets/images/patterns/cloud-native-patterns-side-white.png"
+                     data-logo-for-light="/assets/images/patterns/cloud-native-patterns-side.svg"
+                     data-logo-for-dark="/assets/images/patterns/cloud-native-patterns-side-white.png"
+                     id="logo-dark-light"
+                     alt="Cloud native design patterns"
+                     style="height: 4rem;"
+                     loading="lazy" />
             </div>
             <h2 class="feature-title">Access the <span class="special-text">Cloud Native Designs</span> for Kubernetes</h2>
-            <p>Design and manage all of your cloud native infrastructure using the design configurator in Meshery or start from a template using the patterns from the catalog.
+            <p>
+                Design and manage all of your cloud native infrastructure using the design configurator in Meshery or start from a template using the patterns from the catalog.
+            </p>
             <div class="button-para">
                 <a href="/catalog" class="highlight">View Complete Catalog</a>
             </div>
-            </p>
         </div>
         <div class="image flex" style="flex-flow: column wrap;">
-                {% include meshery-catalog.html %}
+            {% include meshery-catalog.html %}
         </div>
     </div>
 </section>


### PR DESCRIPTION
This PR fixes #2605

**Description**
As requested by @leecalcote in the community Slack, I have updated the Features page (`_includes/features.html`) with the following changes:

- **Terminology Update**: Replaced all "Service Mesh" references with "Cloud Native" in text, alt tags, and image asset paths.
- **Section Reordering**: Moved the "Performance" section to the bottom of the features list (below the Environments section).
- **Feature Addition**: Added the "Use the Cloud Native Performance standard" bullet point to the performance list.
- **HTML Fix**: Ensured proper nesting and closure of section tags for consistent rendering.

**Notes for Reviewers**
I have verified that all "service mesh" keywords are removed from this file. I also updated the data-caption and image paths to ensure consistent branding across the page.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.