### PR TITLE
Fix catalog sync paths in update-catalog workflow

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -146,8 +146,8 @@ jobs:
 
       - name: sync catalog directories to docs
         run: |
-          rsync -av --delete meshery.io/collections/_catalog/ meshery/docs/_catalog/
-          rsync -av --delete meshery.io/catalog/ meshery/docs/catalog/
+          rsync -av --delete meshery.io/collections/_catalog/ meshery/docs/catalog/
+          rsync -av --delete meshery.io/catalog/ meshery/docs/data/catalog/
 
       - name: Pull latest changes from meshery/meshery
         run: |


### PR DESCRIPTION
Updated rsync commands to sync catalog directories correctly.

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
