### PR TITLE
[Website] Slow Community and Resources navbar dropdown animation (#2641)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -63,7 +63,11 @@
 <!-- Site Navigation Menu -->
 <script type="text/javascript">
 	jQuery(document).ready(function ($) {
-		jQuery('.stellarnav').stellarNav({ breakpoint: 1140 });
+		jQuery('.stellarnav').stellarNav({
+			breakpoint: 1140,
+			openingSpeed: 280,
+			closingDelay: 200
+		});
 		jQuery('.stellarnav.mobile').css('text-align', 'end');
 	});
 </script>


### PR DESCRIPTION
## Related Issue
Closes #2641

## Summary
- slow the desktop dropdown animation for Community and Resources`n- increase the opening speed value for a smoother reveal
- add a slightly longer closing delay so the menu feels less abrupt

## Testing
- rebuilt the site locally in Docker
- verified http://localhost:4000 responds successfully
