### PR TITLE
Allow Ruby 3.2.2 and newer for Jekyll

### DIFF
--- a/.github/agents/code-contributor.md
+++ b/.github/agents/code-contributor.md
@@ -28,7 +28,7 @@ You are an expert-level software engineering agent specialized in contributing t
 - **Languages**: HTML5, SCSS (Dart Sass), JavaScript (ES6+), Liquid, YAML
 - **Styling**: SCSS modules imported via `@use` in `css/screen.scss`
 - **Theming**: CSS variables defined in `_sass/rootvariables.scss`
-- **Ruby Version**: Always match version in `Gemfile` (currently 3.2.2)
+- **Ruby Version**: Use a Ruby version supported by `Gemfile` (minimum `3.2.2`)
 
 ### DevOps & Tools
 - **Build System**: `make` is the ONLY supported interface.

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
-ruby '3.2.2'
+ruby '>= 3.2.2'
 
 gem 'jekyll', '4.4.1'
+gem 'logger'                    # stdlib in Ruby <= 3.x, explicit in Ruby >= 4.0
 gem 'tzinfo-data', platforms: [:x64_mingw]
 gem 'wdm', '>= 0.1.0'
 gem 'eventmachine', '1.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     octopress-hooks (2.6.2)
       jekyll (>= 2.0)
@@ -182,6 +183,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-seo-tag (= 2.8.0)
   jekyll-sitemap (= 1.4.0)
+  logger
   octopress-paginate
   tzinfo
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Before contributing, please review the [Contribution Flow](https://github.com/me
 
 - _The Meshery site is built using Jekyll - a simple static site generator! You can learn more about Jekyll and setting up your development environment in the [Jekyll Docs](https://jekyllrb.com/docs/)._
 
-- First [install Ruby](https://jekyllrb.com/docs/installation/), then install Jekyll and Bundler. ( **Note** : Install the same version of Ruby as mentioned in the [Gemfile](https://github.com/meshery/meshery.io/blob/master/Gemfile) )
-- If your installed Ruby version does not match the one specified in the Gemfile, you can use [RVM](https://rvm.io/rvm/install) to install the correct version for your operating system.
+- First [install Ruby](https://jekyllrb.com/docs/installation/), then install Jekyll and Bundler. ( **Note** : Install Ruby 3.2.2 or newer, as specified in the [Gemfile](https://github.com/meshery/meshery.io/blob/master/Gemfile) )
+- If your installed Ruby version is older than the minimum specified in the Gemfile, you can use [RVM](https://rvm.io/rvm/install) to install a compatible version for your operating system.
 
 ### 2. Get the code
 


### PR DESCRIPTION
## Summary
- relax the Gemfile Ruby requirement from an exact 3.2.2 pin to Ruby 3.2.2 or newer
- add `logger` explicitly so the Jekyll bundle works on Ruby 4.x
- update contributor guidance to describe 3.2.2 as the minimum supported Ruby version

## Notes
- `.ruby-version` remains `3.2.2` as the local default baseline
- CI continues to run on Ruby 3.2.2, while local development can use newer Rubies