### PR TITLE
 Fix: Hide "No results match your filters" when catalog is empty (#2653)

### DIFF
--- a/_includes/patterns-filter.html
+++ b/_includes/patterns-filter.html
@@ -513,9 +513,9 @@ function showFilterCards() {
                          globalCategoryList.length === 0 && 
                          globalPatternTypeList.length === 0;
   
-  // Update "not found" message
+  //  Only show "not found" if the catalog actually has items AND filters hid all of them
   const noCard = document.getElementById("not-found");
-  noCard.style.display = matchingCards.length > 0 ? "none" : "block";
+  noCard.style.display =(patternCards.length > 0 && matchingCards.length === 0) ? "block" : "none";
   
   // Get pagination elements
   const paginationButtons = document.querySelector(".pagination");


### PR DESCRIPTION
Fixes #2653

### What was happening
Currently, the catalog designs page displays a false *"No results match your filters"* error message. This is happening because the `collections/_catalog` directory is currently empty (due to backend API timeouts in `cloud.layer5.io` during CI sync). The frontend filtering logic (`_includes/patterns-filter.html`) was blindly checking if `matchingCards.length === 0` and displaying the error message, failing to account for the fact that the initial list of cards is simply `0`.

### What changed
Updated `_includes/patterns-filter.html` so the "Not Found" error message only triggers if the catalog actually contains items *and* the applied filters hid all of them.

```javascript
// Only show "not found" if the catalog actually has items AND filters hid all of them
noCard.style.display = (patternCards.length > 0 && matchingCards.length === 0) ? "block" : "none";


BEFORE :
<img width="1887" height="836" alt="before" src="https://github.com/user-attachments/assets/9ecd4bd8-c4d8-4812-8fe9-00b7eb854aa8" />

AFTER:
<img width="1907" height="907" alt="after" src="https://github.com/user-attachments/assets/e18616dc-6f99-4856-a33f-e2cc2a12aa1c" />
