### PR TITLE
Fix Liquid append syntax warnings

### DIFF
--- a/_includes/partials/individual-component.html
+++ b/_includes/partials/individual-component.html
@@ -37,7 +37,8 @@
             <p>MODELS</p>
             <div>
               {% for item in pattern.compatibility %}
-              <a href="{{ '/catalog/models/' | append: (item | slugify) | relative_url }}">
+              {% assign item_slug = item | slugify %}
+              <a href="{{ '/catalog/models/' | append: item_slug | relative_url }}">
                 {{ item | capitalize }}
               </a>
               {% unless forloop.last %}, {% endunless %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -51,8 +51,9 @@ paginate:
             {% assign parts = category_count | split: '|' %}
             {% assign category = parts[1] %}
             {% assign count = parts[0] | plus: 0 %}
+            {% assign category_slug = category | slugify %}
             <li>
-              <a href="{{ '/blog/category/' | append: (category | slugify) | relative_url }}">
+              <a href="{{ '/blog/category/' | append: category_slug | relative_url }}">
                 {{ category }} <span class="cat-count">({{ count }})</span>
               </a>
             </li>


### PR DESCRIPTION
## Summary
- replace the invalid parenthesized Liquid filter in `blog/index.html` with an intermediate slug assignment
- apply the same Liquid-safe pattern in `_includes/partials/individual-component.html`
- remove the Jekyll build warning caused by `append: (value | slugify)` expressions

## Testing
- bundle exec jekyll build