### PR TITLE
feat: add hyperlinks to related meshery orgs on gsoc page

### DIFF
--- a/_layouts/program-index.html
+++ b/_layouts/program-index.html
@@ -23,17 +23,28 @@ layout: default
             where_exp:
             "item", "item.url != page.link " | sort: "url" | reverse %}
             {% for program in program_pages %}
-            <div class="project-item" style="margin-bottom: 1.5rem;">
-                <a href="{{ program.url | relative_url }}"
-                    style="display: flex; align-items: center; justify-content: space-between; padding: 1rem 1.5rem; border: 1px solid rgba(0, 211, 169, 0.3); border-radius: 8px; text-decoration: none; transition: all 0.3s ease;">
+            <div class="project-item"
+                style="margin-bottom: 1.5rem; border: 1px solid rgba(0, 211, 169, 0.3); border-radius: 8px;">
+                <div
+                    style="display: flex; align-items: center; justify-content: space-between; padding: 1rem 1.5rem; text-decoration: none; transition: all 0.3s ease;">
                     <span>
                         <h3 style="margin: 0; font-size: 1.25rem;">{{ program.title }}</h3>
                         {% if program.excerpt %}
                         <p style="margin: 0.25rem 0 0 0; font-size: 0.9rem; opacity: 0.7;">{{ program.excerpt }}</p>
                         {% endif %}
+                        {% if program.gsoc_links %}
+                        <div style="margin-top: 0.35rem;">
+                            {% for link in program.gsoc_links %}
+                            <a href="{{ link.url }}" target="_blank"
+                                style="font-size: 0.8rem; color: #00D3A9; text-decoration: none;">
+                                View on GSOC Page ({{ link.label }})
+                            </a><br>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     </span>
-                    <span style="font-size: 1.5rem; color: #00D3A9;">→</span>
-                </a>
+                    <a href="{{ program.url | relative_url }}" style="font-size: 1.5rem; color: #00D3A9;">→</a>
+                </div>
             </div>
             {% endfor %}
         </div>

--- a/_layouts/program-index.html
+++ b/_layouts/program-index.html
@@ -35,7 +35,7 @@ layout: default
                         {% if program.gsoc_links %}
                         <div style="margin-top: 0.35rem;">
                             {% for link in program.gsoc_links %}
-                            <a href="{{ link.url }}" target="_blank"
+                            <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer"
                                 style="font-size: 0.8rem; color: #00D3A9; text-decoration: none;">
                                 View on GSOC Page ({{ link.label }})
                             </a><br>
@@ -43,7 +43,7 @@ layout: default
                         </div>
                         {% endif %}
                     </span>
-                    <a href="{{ program.url | relative_url }}" style="font-size: 1.5rem; color: #00D3A9;">→</a>
+                    <a href="{{ program.url | relative_url }}" style="font-size: 1.5rem; color: #00D3A9;" aria-label="View {{ program.title }} details">→</a>
                 </div>
             </div>
             {% endfor %}

--- a/collections/_programs/gsoc/gsoc_2019.md
+++ b/collections/_programs/gsoc/gsoc_2019.md
@@ -7,6 +7,12 @@ image: images/programs/gsoc.png
 thumbnail: images/program/gsoc.svg
 link: /programs/gsoc/2019
 
+gsoc_links: 
+  - label: Linkerd
+    url: https://summerofcode.withgoogle.com/archive/2019/organizations/6364232440872960
+  - label: CNCF
+    url: https://summerofcode.withgoogle.com/archive/2019/organizations/6034778267058176
+    
 subtitle: "Meshery participation for 2019"
 
 description: |

--- a/collections/_programs/gsoc/gsoc_2020.md
+++ b/collections/_programs/gsoc/gsoc_2020.md
@@ -7,6 +7,10 @@ image: images/programs/gsoc.png
 thumbnail: images/programs/gsoc.svg
 link: /programs/gsoc/2020
 
+gsoc_links: 
+  - label: CNCF
+    url: https://summerofcode.withgoogle.com/archive/2020/organizations/5861737481371648
+    
 subtitle: "Meshery participation for 2020"
 
 description: |

--- a/collections/_programs/gsoc/gsoc_2025.md
+++ b/collections/_programs/gsoc/gsoc_2025.md
@@ -8,6 +8,12 @@ image: images/programs/gsoc.png
 thumbnail: images/programs/gsoc.svg
 link: /programs/gsoc/2025
 
+gsoc_links:
+  - label: Meshery
+    url: https://summerofcode.withgoogle.com/programs/2025/organizations/meshery
+  - label: CNCF
+    url: https://summerofcode.withgoogle.com/programs/2025/organizations/cncf
+    
 description: |
   As a self-service engineering platform, Meshery enables collaborative design and operation of cloud native infrastructure.
   As a mentee, you will learn cloud native infrastructure management techniques, and will increase your understanding of distributed systems challenges and how to properly implement best-practice patterns of modern software design.

--- a/collections/_programs/gsoc/gsoc_2026.md
+++ b/collections/_programs/gsoc/gsoc_2026.md
@@ -8,6 +8,10 @@ image: images/programs/gsoc.png
 thumbnail: images/programs/gsoc.svg
 link: /programs/gsoc/2026
 
+gsoc_links:
+  - label: Meshery
+    url: https://summerofcode.withgoogle.com/programs/2026/organizations/meshery
+    
 description: |
   As a self-service engineering platform, Meshery enables collaborative design and operation of cloud native infrastructure.
   As a mentee, you will learn cloud native infrastructure management techniques, and will increase your understanding of distributed systems challenges and how to properly implement best-practice patterns of modern software design.


### PR DESCRIPTION
**Description**

This PR fixes #2661 and adds hyperlinks to the organisation pages for each of the entries in the GSoC program collection.


**Notes for Reviewers**

- For the year 2023, I didn't find any organisation (Meshery, CNCF, others) that lists the mentioned projects.
- The anchor is removed from the card div and attached to the arrow to avoid nested `<a>` tags 

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

<img width="982" height="821" alt="image" src="https://github.com/user-attachments/assets/064651cc-eb69-4741-b1fe-c80c694237f4" />

