### PR TITLE
feat: add in-page navigation to LFX program pages

### DIFF
--- a/_layouts/lfx.html
+++ b/_layouts/lfx.html
@@ -2,29 +2,18 @@
 layout: default
 ---
 
-<div id="top" class="page text-container">
+<div class="flex-container">
+    <div id="top" class="page text-container lfx-page">
 
-    <div class="cover" style="z-index: 20">
+        <div class="cover" style="z-index: 20">
 
-        <div class="toc">
-            <h3 class="toc-title">On this page</h3>
-            <ul class="toc-list">
+            <div class="project-details">
                 {% for term in page.terms %}
-                <li><a href="#{{ term.name | slugify }}">{{ term.name }}</a></li>
-                {% endfor %}
-                {% if page.timeline %}
-                <li><a href="#timeline">Timeline</a></li>
-                {% endif %}
-            </ul>
-        </div>
+                <h2 id="{{ term.name | slugify }}"><span class="sub_headings">{{ term.name }}</span></h2>
 
-        <div class="project-details">
-            {% for term in page.terms %}
-            <h2 id="{{ term.name | slugify }}"><span class="sub_headings">{{ term.name }}</span></h2>
-
-            {% for project in term.projects %}
-            <div class="project-item">
-                <h3>{{ project.title }}</h3>
+                {% for project in term.projects %}
+                <div class="project-item">
+                    <h3>{{ project.title }}</h3>
 
                 {% if project.lfx_link %}
                 <a class="issue" href="{{ project.lfx_link }}">Open on LFX Mentorship</a>
@@ -94,17 +83,17 @@ layout: default
                 <h4 class="project-list">Issue:</h4>
                 <a class="issue" href="{{ project.issue }}">{{ project.issue }}</a>
                 {% endif %}
+                </div>
+                {% endfor %}
+                {% endfor %}
             </div>
-            {% endfor %}
-            {% endfor %}
         </div>
-    </div>
 
-    {% if page.timeline %}
-    <h3 class="cohort_title" id="timeline">{{ page.timeline_title }}</h3>
-    <div class="program">
-        <div class="community-details">
-            <p><span class="sub_headings">Full-Time Terms:</span></p>
+        {% if page.timeline %}
+        <h3 class="cohort_title" id="timeline">{{ page.timeline_title }}</h3>
+        <div class="program">
+            <div class="community-details">
+                <p><span class="sub_headings">Full-Time Terms:</span></p>
 
             {% for term in page.timeline %}
             <h4>{{ term.name }}</h4>
@@ -126,26 +115,39 @@ layout: default
                 </a>
             </div>
             {% endif %}
+            </div>
         </div>
-    </div>
-    {% endif %}
+        {% endif %}
 
-    {% if page.part_time_note %}
-    <div class="program">
-        <div class="community-details">
-            <h4>{{ page.part_time_note }}</h4>
+        {% if page.part_time_note %}
+        <div class="program">
+            <div class="community-details">
+                <h4>{{ page.part_time_note }}</h4>
+            </div>
         </div>
-    </div>
-    {% endif %}
+        {% endif %}
 
-    {% if page.additional_info %}
-    <div class="program">
-        <div class="community-details">
-            <p class="sub_headings">{{ page.additional_info_title | default: "Additional information" }}</p>
-            <p>{{ page.additional_info }}</p>
+        {% if page.additional_info %}
+        <div class="program">
+            <div class="community-details">
+                <p class="sub_headings">{{ page.additional_info_title | default: "Additional information" }}</p>
+                <p>{{ page.additional_info }}</p>
+            </div>
         </div>
+        {% endif %}
     </div>
-    {% endif %}
+
+    <div class="toc">
+        <h3 class="toc-title">On this page</h3>
+        <ul class="toc-list">
+            {% for term in page.terms %}
+            <li><a class="tocListBtn" href="#{{ term.name | slugify }}">{{ term.name }}</a></li>
+            {% endfor %}
+            {% if page.timeline %}
+            <li><a class="tocListBtn" href="#timeline">Timeline</a></li>
+            {% endif %}
+        </ul>
+    </div>
 </div>
 <a id="button-scroll-to-up" style="text-decoration: none; color: var(--color-white);"></a>
 

--- a/_layouts/lfx.html
+++ b/_layouts/lfx.html
@@ -96,7 +96,6 @@ layout: default
                 {% endif %}
             </div>
             {% endfor %}
-            <a href="#top" class="back-to-top">Back to Top</a>
             {% endfor %}
         </div>
     </div>
@@ -129,7 +128,6 @@ layout: default
             {% endif %}
         </div>
     </div>
-    <a href="#top" class="back-to-top">Back to Top</a>
     {% endif %}
 
     {% if page.part_time_note %}
@@ -149,6 +147,7 @@ layout: default
     </div>
     {% endif %}
 </div>
+<a id="button-scroll-to-up" style="text-decoration: none; color: var(--color-white);"></a>
 
 <div class="text subscribe program__subscribe">
     {% include subscribe.html %}

--- a/_layouts/lfx.html
+++ b/_layouts/lfx.html
@@ -12,7 +12,9 @@ layout: default
                 {% for term in page.terms %}
                 <li><a href="#{{ term.name | slugify }}">{{ term.name }}</a></li>
                 {% endfor %}
+                {% if page.timeline %}
                 <li><a href="#timeline">Timeline</a></li>
+                {% endif %}
             </ul>
         </div>
 

--- a/_layouts/lfx.html
+++ b/_layouts/lfx.html
@@ -2,13 +2,23 @@
 layout: default
 ---
 
-<div class="page text-container">
+<div id="top" class="page text-container">
 
     <div class="cover" style="z-index: 20">
 
+        <div class="toc">
+            <h3 class="toc-title">On this page</h3>
+            <ul class="toc-list">
+                {% for term in page.terms %}
+                <li><a href="#{{ term.name | slugify }}">{{ term.name }}</a></li>
+                {% endfor %}
+                <li><a href="#timeline">Timeline</a></li>
+            </ul>
+        </div>
+
         <div class="project-details">
             {% for term in page.terms %}
-            <h2><span class="sub_headings">{{ term.name }}</span></h2>
+            <h2 id="{{ term.name | slugify }}"><span class="sub_headings">{{ term.name }}</span></h2>
 
             {% for project in term.projects %}
             <div class="project-item">
@@ -84,12 +94,13 @@ layout: default
                 {% endif %}
             </div>
             {% endfor %}
+            <a href="#top" class="back-to-top">Back to Top</a>
             {% endfor %}
         </div>
     </div>
 
     {% if page.timeline %}
-    <h3 class="cohort_title">{{ page.timeline_title }}</h3>
+    <h3 class="cohort_title" id="timeline">{{ page.timeline_title }}</h3>
     <div class="program">
         <div class="community-details">
             <p><span class="sub_headings">Full-Time Terms:</span></p>
@@ -116,6 +127,7 @@ layout: default
             {% endif %}
         </div>
     </div>
+    <a href="#top" class="back-to-top">Back to Top</a>
     {% endif %}
 
     {% if page.part_time_note %}

--- a/css/program.css
+++ b/css/program.css
@@ -78,6 +78,23 @@ h1,h2,h3,h4,h5,h6{
   color: var(--color-secondary-dark);
 }
 
+.toc-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--color-secondary-dark);
+}
+
+.toc ul {
+  list-style-type: none;
+  padding-left: 1rem;
+  border-left: 2px solid #00d4ab;
+}
+
+.toc ul li {
+  margin-bottom: 0.5rem;
+} 
+
 .title {
   text-align: center;
   color: #ffffff;
@@ -171,6 +188,12 @@ a:active {
 
 .participate-button:hover {
   background-color: #00d3a9;
+}
+
+.back-to-top {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+  display: block;
 }
 
 .subhead {

--- a/css/program.css
+++ b/css/program.css
@@ -190,10 +190,35 @@ a:active {
   background-color: #00d3a9;
 }
 
-.back-to-top {
-  margin-top: 3rem;
-  margin-bottom: 3rem;
-  display: block;
+#button-scroll-to-up {
+  display: inline-block;
+  background-color: var(--brand-color-secondary);
+  width: 55.5px;
+  height: 55.5px;
+  text-align: center;
+  border-radius: 50%;
+  position: fixed;
+  bottom:-60px;
+  right: 30px;
+  z-index: 99999;
+  cursor: pointer;
+  transition: bottom 0.2s;
+}
+#button-scroll-to-up::after {
+  border-style: solid;
+	border-width: 0.25em 0.25em 0 0;
+	content: '';
+	display: inline-block;
+	height: 0.7em;
+	position: relative;
+  top: 1.4em;
+	transform: rotate(-45deg);
+	vertical-align: center;
+	width: 0.7em;
+  color: #fff;
+}
+#button-scroll-to-up.show {
+  bottom: 20px;
 }
 
 .subhead {

--- a/css/program.css
+++ b/css/program.css
@@ -78,6 +78,29 @@ h1,h2,h3,h4,h5,h6{
   color: var(--color-secondary-dark);
 }
 
+.lfx-page {
+  flex: 1 1 auto;
+}
+
+.toc {
+  position: sticky;
+  top: 10rem;
+  flex: 0 0 250px;
+  height: fit-content;
+  width: 250px;
+  padding: 1rem;
+  background: var(--background-grey);
+  box-shadow: var(--box-shadow-primary);
+  border-radius: 7px;
+}
+
+.flex-container {
+  display: flex;
+  gap: 2rem;
+  width: full-width;
+  padding: 0 1.5rem;
+}
+
 .toc-title {
   font-size: 1rem;
   font-weight: 600;
@@ -88,12 +111,16 @@ h1,h2,h3,h4,h5,h6{
 .toc ul {
   list-style-type: none;
   padding-left: 1rem;
-  border-left: 2px solid #00d4ab;
 }
 
 .toc ul li {
   margin-bottom: 0.5rem;
 } 
+
+.toc ul li a {
+  color: var(--color-secondary-dark);
+  text-decoration: none;
+}
 
 .title {
   text-align: center;
@@ -363,7 +390,6 @@ img {
 }
 
 @media screen and (max-width: 767px) {
- 
   p{
     padding-left: 0.4rem;
   }


### PR DESCRIPTION
**Description**

This PR fixes #2666 by adding in-page navigation, including jump to a specific term or timeline and back to top links, to the LFX program pages.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<img width="1811" height="676" alt="image" src="https://github.com/user-attachments/assets/f06b49eb-70e3-48fb-87bc-400c17b861b6" />
<br>
<img width="1811" height="676" alt="image" src="https://github.com/user-attachments/assets/c930d692-9762-48e9-a8fc-90d361133af3" />

