### PR TITLE
fix: correct typo from 'forum' to 'form' in popup-text

### DIFF
--- a/js/community-popup.js
+++ b/js/community-popup.js
@@ -17,7 +17,7 @@
       <p>Welcome! Fill in the community member form to receive updates about meetings and resources.</p>
       </div>
 
-      <a class="popup-button" href="https://meshery.io/newcomers" target="_blank"><p class="popup-button-text">Community Forum</p></a>
+      <a class="popup-button" href="https://meshery.io/newcomers" target="_blank"><p class="popup-button-text">Community Form</p></a>
       </div>`;
 
     el.querySelector(".close-btn").addEventListener("click", function () {

--- a/js/community-popup.js
+++ b/js/community-popup.js
@@ -17,7 +17,7 @@
       <p>Welcome! Fill in the community member form to receive updates about meetings and resources.</p>
       </div>
 
-      <a class="popup-button" href="https://meshery.io/newcomers" target="_blank"><p class="popup-button-text">Community Form</p></a>
+      <a class="popup-button" href="https://meshery.io/newcomers" target="_blank" rel="noopener noreferrer"><p class="popup-button-text">Community Form</p></a>
       </div>`;
 
     el.querySelector(".close-btn").addEventListener("click", function () {


### PR DESCRIPTION
**Description**

**Notes for Reviewers**
Fixed the typo from 'forum' to 'form'

**Screenshot**
<img width="381" height="300" alt="image" src="https://github.com/user-attachments/assets/7ce2fa73-71ab-4121-b4dc-780c2c383600" />



**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
