### PR TITLE
Add dedicated Certifications page at /community/certifications

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -57,6 +57,11 @@
       external: false
       new_window: false
       img_src: /assets/images/nav-icons/Recognition.svg
+    - name: Certifications
+      link: /community/certifications
+      external: false
+      new_window: false
+      img_src: /assets/images/nav-icons/Certifications.svg
     - name: Discussion forums
       link: /community#discussion-forums
       new_window: false

--- a/assets/images/nav-icons/Certifications.svg
+++ b/assets/images/nav-icons/Certifications.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100" fill="none">
+<path d="M50,8 L94,32 L50,56 L6,32 Z" fill="black"/>
+<path d="M24,40 L24,64 C24,73 36,80 50,80 C64,80 76,73 76,64 L76,40 L50,53 Z" fill="black"/>
+<path d="M88,32 L88,60 Q88,64 84,66 L84,74 Q84,76 86,76 L90,76 Q92,76 92,74 L92,66 Q88,64 88,60 L92,32 Q92,28 90,28 Q88,28 88,32 Z" fill="black"/>
+</svg>

--- a/certifications.md
+++ b/certifications.md
@@ -1,0 +1,62 @@
+---
+layout: page
+title: Certifications
+permalink: /community/certifications
+description: "Validate your Meshery skills and expertise with the Meshery Certification Program."
+---
+
+The Meshery Certification Program offers a structured pathway for professionals to validate their skills in managing and contributing to Meshery. The program includes certifications for administrators, developers, and open source contributors, each tailored to different levels of expertise and roles within the Meshery ecosystem.
+
+<div style="text-align: center;padding:20px">
+<a href="https://playground.meshery.io/extension/meshmap?catalog-design=c2141477-379b-432e-b47e-1c89600235a5"><img alt="Meshery Certification Program" src="{{ '/assets/images/posts/2025/certified-meshery-contributor/meshery-certification-program.png' | relative_url }}" style="width:100%;max-width:800px;" /></a><br />
+<a href="https://playground.meshery.io/extension/meshmap?catalog-design=c2141477-379b-432e-b47e-1c89600235a5">Explore the Meshery Certification Program design</a>
+</div>
+
+<h3>Certification Tracks</h3>
+
+The Meshery Certification program offers specialized tracks designed for distinct audiences. Each track is structured with progressive tiers, catering to specific levels of expertise and fostering growth within the community.
+
+<h4>Administrators Track</h4>
+
+Tailored for operators and advanced users of Meshery, the Administrators track validates foundational knowledge through deep expertise in extending and troubleshooting Meshery as a platform.
+
+**Certifications:**
+
+1. Certified Meshery Associate
+2. Certified Meshery Professional
+3. Certified Meshery Expert
+
+<h4>Developers Track</h4>
+
+The Developers track targets contributors and engineers focused on building and extending Meshery. Certifications validate skills from open source contributions to advanced development and integration.
+
+**Certifications:**
+
+4. Certified Meshery Contributor
+5. Certified Meshery Developer
+
+<h3>Certified Meshery Contributor (CMC)</h3>
+
+The [Certified Meshery Contributor (CMC)](https://cloud.meshery.io/academy/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor) was launched in October 2025 as the program's first certification — and a first of its kind for the CNCF. It validates technical proficiency in contributing to the Meshery open source project through written assessments across five of Meshery's major [architectural domains](https://docs.meshery.io/architecture): Meshery Server, Meshery CLI, Meshery UI, Meshery Models, and Meshery Extensibility.
+
+<div style="text-align:center;padding:20px">
+<a href="https://cloud.meshery.io/academy/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor">
+<img alt="Certified Meshery Contributor Badge" src="{{ '/assets/images/posts/2025/certified-meshery-contributor/certified-meshery-contributor-badge.png' | relative_url }}" style="width:100%;max-width:200px;" />
+</a>
+</div>
+
+| Detail | Value |
+|---|---|
+| **Track** | Developers |
+| **Target Audience** | Developers, technical writers, and community members |
+| **Exam Format** | Multiple-choice / online assessment |
+| **Duration** | 2 hours |
+| **Passing Score** | 70% |
+| **Cost** | Free |
+| **Validity** | 2 years |
+
+<div style="text-align:center;padding:20px">
+<a href="https://cloud.meshery.io/academy/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor" class="btn btn-primary">Register for the CMC Exam</a>
+</div>
+
+Certification badges are part of Meshery's broader [Recognition Program](/community/recognition), which also includes Achievement, Project, and Community badges. Learn more about the certification launch in the [announcement blog post](/blog/certified-meshery-contributor).

--- a/certifications.md
+++ b/certifications.md
@@ -32,8 +32,10 @@ The Developers track targets contributors and engineers focused on building and 
 
 **Certifications:**
 
-4. Certified Meshery Contributor
-5. Certified Meshery Developer
+<ol start="4">
+<li>Certified Meshery Contributor</li>
+<li>Certified Meshery Developer</li>
+</ol>
 
 ### Certified Meshery Contributor (CMC)
 
@@ -56,7 +58,7 @@ The [Certified Meshery Contributor (CMC)](https://cloud.meshery.io/academy/certi
 | **Validity** | 2 years |
 
 <div style="text-align:center;padding:20px">
-<a href="https://cloud.meshery.io/academy/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor" class="btn btn-primary">Register for the CMC Exam</a>
+<a href="https://cloud.meshery.io/academy/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor" class="highlight">Register for the CMC Exam</a>
 </div>
 
 Certification badges are part of Meshery's broader [Recognition Program](/community/recognition), which also includes Achievement, Project, and Community badges. Learn more about the certification launch in the [announcement blog post](/blog/certified-meshery-contributor).

--- a/certifications.md
+++ b/certifications.md
@@ -12,11 +12,11 @@ The Meshery Certification Program offers a structured pathway for professionals 
 <a href="https://playground.meshery.io/extension/meshmap?catalog-design=c2141477-379b-432e-b47e-1c89600235a5">Explore the Meshery Certification Program design</a>
 </div>
 
-<h3>Certification Tracks</h3>
+### Certification Tracks
 
 The Meshery Certification program offers specialized tracks designed for distinct audiences. Each track is structured with progressive tiers, catering to specific levels of expertise and fostering growth within the community.
 
-<h4>Administrators Track</h4>
+#### Administrators Track
 
 Tailored for operators and advanced users of Meshery, the Administrators track validates foundational knowledge through deep expertise in extending and troubleshooting Meshery as a platform.
 
@@ -26,7 +26,7 @@ Tailored for operators and advanced users of Meshery, the Administrators track v
 2. Certified Meshery Professional
 3. Certified Meshery Expert
 
-<h4>Developers Track</h4>
+#### Developers Track
 
 The Developers track targets contributors and engineers focused on building and extending Meshery. Certifications validate skills from open source contributions to advanced development and integration.
 
@@ -35,7 +35,7 @@ The Developers track targets contributors and engineers focused on building and 
 4. Certified Meshery Contributor
 5. Certified Meshery Developer
 
-<h3>Certified Meshery Contributor (CMC)</h3>
+### Certified Meshery Contributor (CMC)
 
 The [Certified Meshery Contributor (CMC)](https://cloud.meshery.io/academy/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor) was launched in October 2025 as the program's first certification — and a first of its kind for the CNCF. It validates technical proficiency in contributing to the Meshery open source project through written assessments across five of Meshery's major [architectural domains](https://docs.meshery.io/architecture): Meshery Server, Meshery CLI, Meshery UI, Meshery Models, and Meshery Extensibility.
 

--- a/recognition.md
+++ b/recognition.md
@@ -18,11 +18,6 @@ Meshery offers a variety of badges that users and contributors can earn by parti
 
 <h3>Certifications</h3>
 
-The Meshery Certification Program offers a structured pathway for professionals to validate their skills in managing and contributing to Meshery. The program includes certifications for administrators, developers, and open source contributors, each tailored to different levels of expertise and roles within the Meshery ecosystem.
+The Meshery Certification Program validates your skills in managing and contributing to Meshery. Certifications are available for administrators, developers, and open source contributors. The first certification, [Certified Meshery Contributor (CMC)](/blog/certified-meshery-contributor), was launched in October 2025.
 
-<div style="text-align: center;">
-<a href="https://playground.meshery.io/extension/meshmap?catalog-design=c2141477-379b-432e-b47e-1c89600235a5"><img alt="Certified Meshery Contributor Badge" src="{{ '/assets/images/posts/2025/certified-meshery-contributor/meshery-certification-program.png' | relative_url }}" style="width:100%;max-width:400px;"  /></a><br />
-<a href="https://playground.meshery.io/extension/meshmap?catalog-design=c2141477-379b-432e-b47e-1c89600235a5">Explore the Meshery Certification Program design</a>
-</div>
-
-The first certification, [Certified Meshery Contributor (CMC)](/blog/certified-meshery-contributor), in this program was launched in October 2025. This certification validates the skills of developers contributing to the Meshery open source project.
+[View the full Certifications Program &rarr;](/community/certifications)


### PR DESCRIPTION
## Summary

- Adds a new dedicated page at `/community/certifications` with the full Meshery Certification Program overview, certification tracks (Administrators and Developers), CMC exam details, and a register CTA
- Adds a graduation-cap `Certifications.svg` nav icon under `assets/images/nav-icons/`
- Adds a **Certifications** entry to the Community submenu in `_data/navigation.yml`, positioned after Recognition
- Trims the Certifications section on `/community/recognition` to a brief summary with a "View the full Certifications Program →" link, keeping the Recognition page focused on badges

## Test plan

- [ ] Visit `/community/certifications` — page renders with program overview, tracks, CMC details, and register button
- [ ] Visit `/community/recognition` — Certifications section shows the trimmed summary and cross-link
- [ ] Open Community menu in the nav bar — Certifications item appears with the graduation-cap icon, after Recognition
- [ ] Click the nav item — navigates to `/community/certifications`


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJMjvqsqFbpNCg6DKtcy54)_