### PR TITLE
chore: replace deprecated community members page links with github profiles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -172,14 +172,6 @@ defaults:
 
   - scope:
       path: ""
-      type: "contributors"
-    values:
-      _options:
-        image_path:
-          width: 600
-          height: 600
-  - scope:
-      path: ""
     values:
       layout: "page"
   - scope:

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -172,14 +172,6 @@ defaults:
 
   - scope:
       path: ""
-      type: "contributors"
-    values:
-      _options:
-        image_path:
-          width: 600
-          height: 600
-  - scope:
-      path: ""
     values:
       layout: "page"
   - scope:

--- a/collections/_posts/2024/2024-08-14-infrastructure-design-by-meshery.md
+++ b/collections/_posts/2024/2024-08-14-infrastructure-design-by-meshery.md
@@ -9,7 +9,7 @@ categories:
 redirect_from: /blog/infrastructure-design-by-meshery
 featured-image: /assets/images/posts/2024/2024-08-14-infrastructure-design-by-meshery/deep-dive.png
 ---
-On Friday, August 20, 2024, join us for a special enlightning session titled **Infrastructure as Design by Meshery**. This session will be a deep dive into how Meshery can transform your approach to designing, deploying, and managing cloud-native infrastructure.  Join [Whitney Lee](https://www.linkedin.com/in/whitneylee/) from VMware as she hosts [Lee Calcote](https://meshery.io/community/members/lee-calcote), the Founder of Meshery, discussing the intricacies of Meshery and its significant impact on Cloud and Cloud Native space.
+On Friday, August 20, 2024, join us for a special enlightning session titled **Infrastructure as Design by Meshery**. This session will be a deep dive into how Meshery can transform your approach to designing, deploying, and managing cloud-native infrastructure.  Join [Whitney Lee](https://www.linkedin.com/in/whitneylee/) from VMware as she hosts [Lee Calcote](https://github.com/leecalcote), the Founder of Meshery, discussing the intricacies of Meshery and its significant impact on Cloud and Cloud Native space.
 
 <div style="  position: relative;width: 100%;overflow: hidden;padding-top: 56.25%;">
 <iframe style="  position: absolute;top: 0;left: 0;bottom: 0;right: 0;width: 100%;height: 100%;border: none;" src="https://www.youtube.com/embed/JqZ4UZrHdw4?si=lvVMGRqp0WCQFugc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/collections/_posts/2025/09/30/2025-09-30-navigating-hacktoberfest-2025.md
+++ b/collections/_posts/2025/09/30/2025-09-30-navigating-hacktoberfest-2025.md
@@ -57,7 +57,7 @@ Don't confine yourself to a GitHub profile. Engage in meaningful discussions, pa
 
 ### 7. The Virtue of Patience: Embracing the Long Game
 
-Open source is a marathon, not a sprint. Feedback may take time, and collaboration may be challenging. Patience is the glue that holds this ecosystem together. Cultivate it as a fundamental habit in your contributor journey. The Meshery <a href="/community/members">community members</a> invest time, patience, understanding and offer endless hours of support to our contributors. Stick around and benefit. In turn, offer to help others. There's little better way to learn, than through teaching.
+Open source is a marathon, not a sprint. Feedback may take time, and collaboration may be challenging. Patience is the glue that holds this ecosystem together. Cultivate it as a fundamental habit in your contributor journey. The Meshery community members invest time, patience, understanding and offer endless hours of support to our contributors. Stick around and benefit. In turn, offer to help others. There's little better way to learn, than through teaching.
 
 ### 8. Humility and Gratitude: The Essence of Meaningful Contributions
 

--- a/collections/_programs/gsoc/gsoc_2023.md
+++ b/collections/_programs/gsoc/gsoc_2023.md
@@ -50,9 +50,9 @@ projects:
     size: "large (~350 hour project)"
     mentors:
       - name: "Lee Calcote"
-        link: "https://meshery.io/community/members/lee-calcote"
+        link: "https://github.com/leecalcote"
       - name: "Abhishek Kumar"
-        link: "https://meshery.io/community/members/abhishek-kumar"
+        link: "https://github.com/Abhishek-kumar09"
     issue: "https://github.com/meshery/meshery/issues/7019"
 
   - title: "Project 2: MeshModel Kubernetes Ontology Browser"
@@ -70,9 +70,9 @@ projects:
     size: "large (~350 hour project)"
     mentors:
       - name: "Lee Calcote"
-        link: "https://meshery.io/community/members/lee-calcote"
+        link: "https://github.com/leecalcote"
       - name: "Abhishek Kumar"
-        link: "https://meshery.io/community/members/abhishek-kumar"
+        link: "https://github.com/Abhishek-kumar09"
     issue: "https://github.com/meshery/meshery/issues/7465"
 
   - title: "Project 3: Adopt OCI as the packaging and distribution format for Meshery MeshModels"
@@ -88,8 +88,8 @@ projects:
     size: "large (~350 hour project)"
     mentors:
       - name: "Lee Calcote"
-        link: "https://meshery.io/community/members/lee-calcote"
+        link: "https://github.com/leecalcote"
       - name: "Abhishek Kumar"
-        link: "https://meshery.io/community/members/abhishek-kumar"
+        link: "https://github.com/Abhishek-kumar09"
     issue: "https://github.com/meshery/meshery/issues/6447"
 ---

--- a/collections/_programs/lfx/lfx_2023.md
+++ b/collections/_programs/lfx/lfx_2023.md
@@ -21,7 +21,7 @@ terms:
           - "ReactJS"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Ashish Tiwari"
             link: ""
 
@@ -35,9 +35,9 @@ terms:
           - "Golang (nice-to-have)"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Abhishek Kumar"
-            link: "/community/members/abhishek-kumar"
+            link: "https://github.com/Abhishek-kumar09"
 
       - title: "Distributed client-side policy evaluation in WASM and Rego"
         lfx_link: "https://mentorship.lfx.linuxfoundation.org/project/2ee7a912-e26e-4602-9dfc-4febe3842df3"
@@ -49,7 +49,7 @@ terms:
           - "WebAssembly"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Ashish Tiwari"
             link: ""
 
@@ -66,7 +66,7 @@ terms:
           - "Kubernetes"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Xin Huang"
             link: ""
 
@@ -84,7 +84,7 @@ terms:
           - "Augmentation of cuelang-based component generator"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
 
   - name: "LFX Mentorship 2023 Summer Projects"
     projects:
@@ -99,7 +99,7 @@ terms:
           - "Definition of permissions and their enforcement in Meshery with an aim for deep granularity and extensibility with each user interface input component carrying a unique permission key id. Each key is then put into a group of keys in a keychain, keychains assigned to user roles, in turn, roles assigned to users. With users having the ability to create own custom roles, the framework will be dynamic based on the associated server-side permissions for the currently auth’ed user."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Abhishek Kumar"
             link: ""
 
@@ -115,7 +115,7 @@ terms:
           - "a powerful real-time multi-user collaboration experience."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Abhishek Kumar"
             link: ""
 
@@ -134,7 +134,7 @@ terms:
           - "4. Target registries: Meshery Catalog (https://meshery.io/catalog), Artifact Hub."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
 
       - title: "OCI compatible Kubernetes ontology"
         lfx_link: "https://mentorship.lfx.linuxfoundation.org/project/bb8ddf84-31d7-4a89-9e4b-e6aa9601c0db"
@@ -150,7 +150,7 @@ terms:
           - "Augmentation of cuelang-based component generator"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Xin Huang"
             link: ""
 
@@ -167,7 +167,7 @@ terms:
           - "Validation and Reference: For Meshery MeshModel definitions such as cloud-native components and their relationships, the plugin can use the CUE language to provide validation for the CUE input and preview the rendering result. The plugin can also fetch the SMP Model schemas and display them in the IDE for reference."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Xin Huang"
             link: ""
 

--- a/collections/_programs/lfx/lfx_2025.md
+++ b/collections/_programs/lfx/lfx_2025.md
@@ -25,11 +25,11 @@ terms:
           - "AWS"
         mentors:
           - name: "Mia Grenell"
-            link: "/community/members/mia-grenell"
+            link: "https://github.com/miacycle"
           - name: "Sangram Rath"
-            link: "/community/members/sangram-rath"
+            link: "https://github.com/sangramrath"
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
 
       - title: "Meshery Solutions architecture for cloud-native deployments"
         lfx_link: "https://mentorship.lfx.linuxfoundation.org/project/a183c51e-22c6-473b-93f4-6c286993e435"
@@ -45,9 +45,9 @@ terms:
           - name: "Rian Cteulp"
             link: ""
           - name: "Sangram Rath"
-            link: "/community/members/sangram-rath"
+            link: "https://github.com/sangramrath"
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
 
       - title: "Meshery: Relationships for GCP service"
         lfx_link: "https://mentorship.lfx.linuxfoundation.org/project/ed9d4af5-823a-4127-afdf-643c2b623f22"
@@ -63,7 +63,7 @@ terms:
           - name: "James Horton"
             link: ""
           - name: "Mia Grenell"
-            link: "/community/members/mia-grenell"
+            link: "https://github.com/miacycle"
 
   - name: "LFX Mentorship 2025 Spring Projects"
     projects:
@@ -79,9 +79,9 @@ terms:
           - "DevOps"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Mia Grenell"
-            link: "/community/members/mia-grenell"
+            link: "https://github.com/miacycle"
 
       - title: "Hands-on Tutorials Using Meshery Playground"
         lfx_link: "https://crowdfunding.lfx.linuxfoundation.org/projects/4cca92b8-ede6-4396-8d3f-68cfa2ec911c"
@@ -97,7 +97,7 @@ terms:
           - "Experience with cloud-native tools"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "James Horton"
             link: "mailto:james.horton2337@gmail.com"
 
@@ -117,9 +117,9 @@ terms:
           - "CI/CD"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Aabid Sofi"
-            link: "/community/members/aabid-sofi"
+            link: "https://github.com/aabidsofi19"
 
   - name: "LFX Mentorship 2025 Summer Projects"
     projects:
@@ -145,11 +145,11 @@ terms:
           - "Policy Contribution: For advanced interns, there may be opportunities to contribute to the Rego policies that evaluate and enforce these relationships."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Sangram Rath"
-            link: "/community/members/sangram-rath"
+            link: "https://github.com/sangramrath"
           - name: "Mia Grenell"
-            link: "/community/members/mia-grenell"
+            link: "https://github.com/miacycle"
         issue: "https://github.com/meshery/meshery/issues/14793"
 
       - title: "Model Relationships for AWS Services"
@@ -174,11 +174,11 @@ terms:
           - "Policy Contribution: For advanced interns, there may be opportunities to contribute to the Rego policies that evaluate and enforce these relationships."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Sangram Rath"
-            link: "/community/members/sangram-rath"
+            link: "https://github.com/sangramrath"
           - name: "Mia Grenell"
-            link: "/community/members/mia-grenell"
+            link: "https://github.com/miacycle"
         issue: "https://github.com/meshery/meshery/issues/14794"
 
       - title: "Meshery Model Support for kro ResourceGraphDefinitions (RGDs)"
@@ -193,9 +193,9 @@ terms:
           - "DevOps"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Aabid Sofi"
-            link: "/community/members/aabid-sofi"
+            link: "https://github.com/aabidsofi19"
         issue: "https://github.com/meshery/meshery/issues/13520"
 
       - title: "Workflow Engine in Meshery"
@@ -208,7 +208,7 @@ terms:
           - "ReactJS"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Rian Cteulp"
             link: "mailto:rian.cteulp@gmail.com"
         issue: "https://github.com/meshery/meshery/issues/14795"
@@ -227,9 +227,9 @@ terms:
           - "Hands-on cloud-native experience"
         mentors:
           - name: "Sangram Rath"
-            link: "/community/members/sangram-rath"
+            link: "https://github.com/sangramrath"
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
         issue: "https://github.com/meshery/meshery/issues/14796"
 
 timeline_title: "LFX Mentorship 2025 Program Timeline"

--- a/collections/_programs/lfx/lfx_2026.md
+++ b/collections/_programs/lfx/lfx_2026.md
@@ -29,7 +29,7 @@ terms:
             - Integration of Meshery Models (Integrations)
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Kate Suttons"
             link: "mailto:kate.suttons2337@gmail.com"
         issue: "https://github.com/meshery/meshery/issues/17095"
@@ -50,9 +50,9 @@ terms:
           - "Policy Contribution: For advanced interns, there may be opportunities to contribute to the Rego policies that evaluate and enforce these relationships."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Sangram Rath"
-            link: "/community/members/sangram-rath"
+            link: "https://github.com/sangramrath"
         issue: "https://github.com/meshery/meshery/issues/17096"
 
       - title: "Adapter for AI and LLMs"
@@ -77,7 +77,7 @@ terms:
           - "Merged pull requests (PRs) including code, tests, and documentation."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Rian Cteulp"
             link: "mailto:rian.cteulp@gmail.com"
         issue: "https://github.com/meshery/meshery/issues/17097"
@@ -102,7 +102,7 @@ terms:
           - "Comprehensive documentation covering the new graph schema and query patterns."
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "James Horton"
             link: "mailto:james.horton2337@gmail.com"
         issue: "https://github.com/meshery/meshery/issues/17098"
@@ -113,7 +113,7 @@ terms:
         skills: "Golang, Temporal, ReactJS"
         mentors:
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
           - name: "Marcus Ringblom"
             link: "mailto:marcus.ringblom@gmail.com"
         issue: "https://github.com/meshery/meshery/issues/17099"
@@ -140,9 +140,9 @@ terms:
           - "Policy Contribution: For advanced interns, there may be opportunities to contribute to the Rego policies that evaluate and enforce these relationships."
         mentors:
           - name: "Sangram Rath"
-            link: "/community/members/sangram-rath"
+            link: "https://github.com/sangramrath"
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
         issues:
           - "https://github.com/meshery/meshery/issues/14793"
           - "https://github.com/meshery/meshery/issues/14794"
@@ -172,7 +172,7 @@ terms:
           - name: "Rian Cteulp"
             link: "mailto:rian.cteulp@gmail.com"
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
         issue: "https://github.com/meshery/meshery/issues/19092"
 
       - title: "Agentic CI Pipelines: GitHub Action Workflow Overhaul"
@@ -190,9 +190,9 @@ terms:
           - "A suite of agentic workflow definitions (`.md` + compiled `.lock.yml`) committed to the repository, demonstrating Continuous AI applied to Meshery's software delivery lifecycle."
         mentors:
           - name: "Mia Grenell"
-            link: "/community/members/mia-grenell"
+            link: "https://github.com/miacycle"
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
         issue: "https://github.com/meshery/meshery/issues/18795"
 
       - title: "Meshery Models Support for OCI Registries"
@@ -216,7 +216,7 @@ terms:
           - name: "James Horton"
             link: "mailto:james.horton2337@gmail.com"
           - name: "Lee Calcote"
-            link: "/community/members/lee-calcote"
+            link: "https://github.com/leecalcote"
         issue: "https://github.com/meshery/meshery/issues/19093"
 
 timeline_title: "LFX Mentorship 2026 Program Timeline"


### PR DESCRIPTION
### Description
This PR replaces all references to the deprecated `/community/members/*` pages with direct links to the mentors' and maintainers' GitHub profiles, or leaves them as plain text where appropriate. It also cleans up unused default scopes for the deleted `contributors` collection in `_config.yml` and `_config_dev.yml`.

### Changes Made
- **Configurations**: Removed unused `contributors` collection default scopes from `_config.yml` and `_config_dev.yml`.
- **Program Configurations** (`gsoc_2023.md`, `lfx_2023.md`, `lfx_2025.md`, `lfx_2026.md`): Replaced `/community/members/:name` profile links with actual GitHub profile URLs:
  - Lee Calcote -> `https://github.com/leecalcote`
  - Sangram Rath -> `https://github.com/sangramrath`
  - Mia Grenell -> `https://github.com/miacycle`
  - Aabid Sofi -> `https://github.com/aabidsofi19`
  - Abhishek Kumar -> `https://github.com/Abhishek-kumar09`
- **Blog Posts**:
  - `2024-08-14-infrastructure-design-by-meshery.md`: Changed the Lee Calcote profile link to point to his GitHub.
  - `2025-09-30-navigating-hacktoberfest-2025.md`: Removed the link entirely around "community members" to be plain text.



**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
