### PR TITLE
Upgrade meshery.io Go modules to 1.26.4

### DIFF
--- a/.github/workflows/error-code-updater.yml
+++ b/.github/workflows/error-code-updater.yml
@@ -22,9 +22,9 @@ jobs:
           ref: "master"
 
       - name: Setup Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: ./assets/artifact-hub-pkg/go.mod
 
       - name: Run utility
         run: |

--- a/assets/artifact-hub-pkg/go.mod
+++ b/assets/artifact-hub-pkg/go.mod
@@ -1,6 +1,6 @@
-module package.go
+module github.com/meshery/meshery.io/assets/artifact-hub-pkg
 
-go 1.25.5
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/assets/scripts/go.mod
+++ b/assets/scripts/go.mod
@@ -1,5 +1,5 @@
-module hub.go
+module github.com/meshery/meshery.io/assets/scripts
 
-go 1.22.1
+go 1.26.4
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Description

Updates the Go-bearing parts of meshery.io for the Go 1.26.4 toolchain requested in meshery/meshery#19875.

Changes:
- Bumps both meshery.io Go modules to `go 1.26.4`.
- Gives both local modules repository-based module paths so `go build ./...` can run without colliding with source filenames.
- Switches the error-code updater workflow from a hardcoded Go 1.23 setup to `go-version-file` using `assets/artifact-hub-pkg/go.mod`.

## Validation

Run with `GOTOOLCHAIN=go1.26.4` in both `assets/scripts` and `assets/artifact-hub-pkg`:

- `go mod tidy`
- `go build ./...`
- `go test ./...`
- `go vet ./...`

Compatibility sweep:
- No `url.Parse` usage found in the changed modules.
- No `httputil.ReverseProxy` usage found.
- No deprecated RSA PKCS#1 v1.5 API usage found.