### PR TITLE
[UI]: add hover animation and tooltips to blog post social share icons

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -94,7 +94,7 @@ layout: page
   }
 
   .social-share-wrapper .links a[aria-label="Share on LinkedIn"]:hover img {
-    filter: invert(27%) sepia(90%) saturate(600%) hue-rotate(190deg) brightness(85%);
+    filter: invert(24%) sepia(95%) saturate(1200%) hue-rotate(196deg) brightness(95%);
   }
 
   .social-share-wrapper .links a[aria-label="Share on Twitter/X"]:hover img {
@@ -102,7 +102,7 @@ layout: page
   }
 
   .social-share-wrapper .links a[aria-label="Share on Bluesky"]:hover img {
-    filter: invert(27%) sepia(90%) saturate(600%) hue-rotate(190deg) brightness(85%);
+    filter: invert(24%) sepia(95%) saturate(1200%) hue-rotate(196deg) brightness(95%);
   }
 
   .social-share-wrapper .links a::after {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,15 +25,16 @@ layout: page
             </svg>
           </a>
 
-
           {% capture twitter_url %}https://x.com/intent/tweet?text={{ page.title | url_encode }}&url={{ site.url |
           append: page.url | url_encode }}&hashtags=meshery&via=mesheryio{% endcapture %}
           <a href="{{ twitter_url }}" target="_blank" rel="noopener" aria-label="Share on Twitter/X"
             data-share-tooltip="Share on Twitter/X">
-            <img src="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}"
-              data-logo-for-dark="{{ '/assets/images/logos/twitter-light.svg' | relative_url }}"
-              data-logo-for-light="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}" alt="Twitter logo"
-              id="logo-dark-light" width="28" height="28" class="share-icon" />
+            <svg width="28" height="28" viewBox="0 0 1200 1227" fill="none" xmlns="http://www.w3.org/2000/svg"
+              class="share-icon twitter-share">
+              <path fill-rule="evenodd" clip-rule="evenodd"
+                d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z"
+                fill="#3C494F" />
+            </svg>
           </a>
 
           {% capture bluesky_text %}{{ page.title }} by @mesheryio.bsky.social {{ site.url | append: page.url }}{% if
@@ -95,15 +96,16 @@ layout: page
     opacity: 0.45;
   }
 
+  .twitter-share {
+    width: 28px;
+    height: 28px;
+    opacity: 0.45;
+  }
+
   .bluesky-share {
     width: 36px;
     height: 36px;
     opacity: 0.45;
-  }
-
-  .social-share-wrapper .links a[aria-label="Share on Twitter/X"] img {
-    opacity: 0.45;
-    transition: opacity 0.2s ease, filter 0.2s ease;
   }
 
   .social-share-wrapper .links a[aria-label="Share on LinkedIn"]:hover .linkedin-share {
@@ -114,17 +116,24 @@ layout: page
     fill: #0077b5;
   }
 
+  .social-share-wrapper .links a[aria-label="Share on Twitter/X"]:hover .twitter-share {
+    opacity: 1;
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on Twitter/X"]:hover .twitter-share path {
+    fill: #000000;
+  }
+
+  body.dark-mode .social-share-wrapper .links a[aria-label="Share on Twitter/X"]:hover .twitter-share path {
+    fill: #ffffff;
+  }
+
   .social-share-wrapper .links a[aria-label="Share on Bluesky"]:hover .bluesky-share {
     opacity: 1;
   }
 
   .social-share-wrapper .links a[aria-label="Share on Bluesky"]:hover .bluesky-share path {
-    fill: #1185fe;
-  }
-
-  .social-share-wrapper .links a[aria-label="Share on Twitter/X"]:hover img {
-    opacity: 1;
-    filter: brightness(0) invert(1);
+    fill: #0077b5;
   }
 
   .social-share-wrapper .links a::after {
@@ -147,5 +156,11 @@ layout: page
   .social-share-wrapper .links a:hover::after {
     opacity: 1;
     transform: translateX(-50%) translateY(0);
+  }
+
+  body.dark-mode .linkedin-share path,
+  body.dark-mode .twitter-share path,
+  body.dark-mode .bluesky-share path {
+    fill: #ffffff;
   }
 </style>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -80,23 +80,29 @@ layout: page
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 50%;
-    padding: 0.4rem;
-    transition: transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease;
-    opacity: 0.75;
-  }
-
-  .social-share-wrapper .links a:hover {
-    transform: translateY(-3px) scale(1.15);
-    opacity: 1;
-    box-shadow: 0 4px 12px rgba(0, 179, 159, 0.35);
   }
 
   .social-share-wrapper .links a img {
     width: 28px;
     height: 28px;
     display: block;
-    transition: filter 0.3s ease;
+    transition: filter 0.2s ease, transform 0.2s ease;
+  }
+
+  .social-share-wrapper .links a:hover img {
+    transform: none;
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on LinkedIn"]:hover img {
+    filter: invert(27%) sepia(90%) saturate(600%) hue-rotate(190deg) brightness(85%);
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on Twitter/X"]:hover img {
+    filter: invert(1);
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on Bluesky"]:hover img {
+    filter: invert(27%) sepia(90%) saturate(600%) hue-rotate(190deg) brightness(85%);
   }
 
   .social-share-wrapper .links a::after {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,10 +17,12 @@ layout: page
           url_encode }}&summary={{ page.title | url_encode }}{% endcapture %}
           <a href="{{ linkedin_url }}" target="_blank" rel="noopener" aria-label="Share on LinkedIn"
             data-share-tooltip="Share on LinkedIn">
-            <img src="{{ '/assets/images/logos/linkedin-dark.svg' | relative_url }}"
-              data-logo-for-dark="{{ '/assets/images/logos/linkedin-light.svg' | relative_url }}"
-              data-logo-for-light="{{ '/assets/images/logos/linkedin-dark.svg' | relative_url }}" alt="LinkedIn logo"
-              id="logo-dark-light" />
+            <svg width="28" height="28" viewBox="0 0 49 48" fill="none" xmlns="http://www.w3.org/2000/svg"
+              class="share-icon linkedin-share">
+              <path fill-rule="evenodd" clip-rule="evenodd"
+                d="M9.91333 7C8.58048 7 7.5 8.08048 7.5 9.41333V38.5866C7.5 39.9194 8.58049 40.9999 9.91333 40.9999H39.0867C40.4195 40.9999 41.5 39.9194 41.5 38.5866V9.41333C41.5 8.08048 40.4195 7 39.0867 7H9.91333ZM15.1314 17.5587C16.7604 17.5587 18.0809 16.2382 18.0809 14.6092C18.0809 12.9803 16.7604 11.6597 15.1314 11.6597C13.5025 11.6597 12.1819 12.9803 12.1819 14.6092C12.1819 16.2382 13.5025 17.5587 15.1314 17.5587ZM20.7822 19.7385H25.6704V21.9778C25.6704 21.9778 26.9969 19.3248 30.6061 19.3248C33.8257 19.3248 36.4928 20.9109 36.4928 25.7452V35.9395H31.4271V26.9805C31.4271 24.1287 29.9046 23.815 28.7444 23.815C26.3367 23.815 25.9245 25.8919 25.9245 27.3525V35.9395H20.7822V19.7385ZM17.7026 19.7385H12.5603V35.9395H17.7026V19.7385Z"
+                fill="#3C494F" />
+            </svg>
           </a>
 
 
@@ -31,7 +33,7 @@ layout: page
             <img src="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}"
               data-logo-for-dark="{{ '/assets/images/logos/twitter-light.svg' | relative_url }}"
               data-logo-for-light="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}" alt="Twitter logo"
-              id="logo-dark-light" />
+              id="logo-dark-light" width="28" height="28" class="share-icon" />
           </a>
 
           {% capture bluesky_text %}{{ page.title }} by @mesheryio.bsky.social {{ site.url | append: page.url }}{% if
@@ -39,10 +41,11 @@ layout: page
           {% capture bluesky_url %}https://bsky.app/intent/compose?text={{ bluesky_text | url_encode }}{% endcapture %}
           <a href="{{ bluesky_url }}" target="_blank" rel="noopener" aria-label="Share on Bluesky"
             data-share-tooltip="Share on Bluesky">
-            <img src="{{ '/assets/images/logos/bluesky-dark.svg' | relative_url }}"
-              data-logo-for-dark="{{ '/assets/images/logos/bluesky-dark.svg' | relative_url }}"
-              data-logo-for-light="{{ '/assets/images/logos/bluesky-light.svg' | relative_url }}" alt="Bluesky Logo"
-              id="logo-dark-light" />
+            <svg width="28" height="28" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"
+              class="share-icon bluesky-share">
+              <path fill="#3C494F"
+                d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805zm36.254 0C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745z" />
+            </svg>
           </a>
 
         </div>
@@ -82,27 +85,46 @@ layout: page
     justify-content: center;
   }
 
-  .social-share-wrapper .links a img {
-    width: 28px;
-    height: 28px;
-    display: block;
-    transition: filter 0.2s ease, transform 0.2s ease;
+  .share-icon {
+    transition: fill 0.2s ease, opacity 0.2s ease;
   }
 
-  .social-share-wrapper .links a:hover img {
-    transform: none;
+  .linkedin-share {
+    width: 38px;
+    height: 38px;
+    opacity: 0.45;
   }
 
-  .social-share-wrapper .links a[aria-label="Share on LinkedIn"]:hover img {
-    filter: invert(24%) sepia(95%) saturate(1200%) hue-rotate(196deg) brightness(95%);
+  .bluesky-share {
+    width: 36px;
+    height: 36px;
+    opacity: 0.45;
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on Twitter/X"] img {
+    opacity: 0.45;
+    transition: opacity 0.2s ease, filter 0.2s ease;
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on LinkedIn"]:hover .linkedin-share {
+    opacity: 1;
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on LinkedIn"]:hover .linkedin-share path {
+    fill: #0077b5;
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on Bluesky"]:hover .bluesky-share {
+    opacity: 1;
+  }
+
+  .social-share-wrapper .links a[aria-label="Share on Bluesky"]:hover .bluesky-share path {
+    fill: #1185fe;
   }
 
   .social-share-wrapper .links a[aria-label="Share on Twitter/X"]:hover img {
-    filter: invert(1);
-  }
-
-  .social-share-wrapper .links a[aria-label="Share on Bluesky"]:hover img {
-    filter: invert(24%) sepia(95%) saturate(1200%) hue-rotate(196deg) brightness(95%);
+    opacity: 1;
+    filter: brightness(0) invert(1);
   }
 
   .social-share-wrapper .links a::after {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,47 +13,47 @@ layout: page
       <div class="social-share-wrapper">
         <div class="links">
 
-          {% capture linkedin_url %}https://www.linkedin.com/shareArticle?mini=true&url={{ site.url | append: page.url | url_encode }}&summary={{ page.title | url_encode }}{% endcapture %}
-          <a href="{{ linkedin_url }}" target="_blank" rel="noopener" title="Share on LinkedIn">
+          {% capture linkedin_url %}https://www.linkedin.com/shareArticle?mini=true&url={{ site.url | append: page.url |
+          url_encode }}&summary={{ page.title | url_encode }}{% endcapture %}
+          <a href="{{ linkedin_url }}" target="_blank" rel="noopener" title="Share on LinkedIn"
+            data-tooltip="Share on LinkedIn">
             <img src="{{ '/assets/images/logos/linkedin-dark.svg' | relative_url }}"
-                data-logo-for-dark="{{ '/assets/images/logos/linkedin-light.svg' | relative_url }}"
-                data-logo-for-light="{{ '/assets/images/logos/linkedin-dark.svg' | relative_url }}"
-                alt="LinkedIn logo" id="logo-dark-light" />
+              data-logo-for-dark="{{ '/assets/images/logos/linkedin-light.svg' | relative_url }}"
+              data-logo-for-light="{{ '/assets/images/logos/linkedin-dark.svg' | relative_url }}" alt="LinkedIn logo"
+              id="logo-dark-light" />
           </a>
-          
-          
-          {% capture twitter_url %}https://x.com/intent/tweet?text={{ page.title | url_encode }}&url={{ site.url | append: page.url | url_encode }}&hashtags=meshery&via=mesheryio{% endcapture %}
-          <a href="{{ twitter_url }}" target="_blank" rel="noopener" title="Share on Twitter/X">
+
+
+          {% capture twitter_url %}https://x.com/intent/tweet?text={{ page.title | url_encode }}&url={{ site.url |
+          append: page.url | url_encode }}&hashtags=meshery&via=mesheryio{% endcapture %}
+          <a href="{{ twitter_url }}" target="_blank" rel="noopener" title="Share on Twitter/X"
+            data-tooltip="Share on Twitter/X">
             <img src="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}"
-                data-logo-for-dark="{{ '/assets/images/logos/twitter-light.svg' | relative_url }}"
-                data-logo-for-light="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}"
-                alt="Twitter logo" id="logo-dark-light" />
+              data-logo-for-dark="{{ '/assets/images/logos/twitter-light.svg' | relative_url }}"
+              data-logo-for-light="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}" alt="Twitter logo"
+              id="logo-dark-light" />
           </a>
-          
-          {% capture bluesky_text %}{{ page.title }} by @mesheryio.bsky.social {{ site.url | append: page.url }}{% if page.tags %} {% for tag in page.tags %}#{{ tag | replace: ' ', '' }} {% endfor %}{% endif %}{% endcapture %}
+
+          {% capture bluesky_text %}{{ page.title }} by @mesheryio.bsky.social {{ site.url | append: page.url }}{% if
+          page.tags %} {% for tag in page.tags %}#{{ tag | replace: ' ', '' }} {% endfor %}{% endif %}{% endcapture %}
           {% capture bluesky_url %}https://bsky.app/intent/compose?text={{ bluesky_text | url_encode }}{% endcapture %}
-          <a href="{{ bluesky_url }}" target="_blank" rel="noopener" title="Share on Bluesky">
+          <a href="{{ bluesky_url }}" target="_blank" rel="noopener" title="Share on Bluesky"
+            data-tooltip="Share on Bluesky">
             <img src="{{ '/assets/images/logos/bluesky-dark.svg' | relative_url }}"
-                data-logo-for-dark="{{ '/assets/images/logos/bluesky-dark.svg' | relative_url }}"
-                data-logo-for-light="{{ '/assets/images/logos/bluesky-light.svg' | relative_url }}" 
-                alt="Bluesky Logo" id="logo-dark-light" />
+              data-logo-for-dark="{{ '/assets/images/logos/bluesky-dark.svg' | relative_url }}"
+              data-logo-for-light="{{ '/assets/images/logos/bluesky-light.svg' | relative_url }}" alt="Bluesky Logo"
+              id="logo-dark-light" />
           </a>
-          
+
         </div>
       </div>
     </div>
 
     <div class="blog-navigation">
       {% if page.previous.url %}
-      <a
-        class="prev"
-        href="{% include relative-src.html src=page.previous.url %}"
-        >&laquo; {{ page.previous.title }}</a
-      >
+      <a class="prev" href="{% include relative-src.html src=page.previous.url %}">&laquo; {{ page.previous.title }}</a>
       {% endif %} {% if page.next.url %}
-      <a class="next" href="{% include relative-src.html src=page.next.url %}"
-        >{{ page.next.title }} &raquo;</a
-      >
+      <a class="next" href="{% include relative-src.html src=page.next.url %}">{{ page.next.title }} &raquo;</a>
       {% endif %}
     </div>
   </div>
@@ -61,19 +61,63 @@ layout: page
 
 
 <style>
+  .social-share p {
+    letter-spacing: .15rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
 
-.social-share p{
-  letter-spacing: .15rem;
-  font-size: 1.5rem;
-  font-weight: 700;
-  text-transform: uppercase;
+  .social-share-wrapper .links {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    margin-top: .8rem;
+  }
 
-}
-.social-share-wrapper .links {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  margin-top: .8rem;
-}
+  .social-share-wrapper .links a {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    padding: 0.4rem;
+    transition: transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease;
+    opacity: 0.75;
+  }
 
+  .social-share-wrapper .links a:hover {
+    transform: translateY(-3px) scale(1.15);
+    opacity: 1;
+    box-shadow: 0 4px 12px rgba(0, 179, 159, 0.35);
+  }
+
+  .social-share-wrapper .links a img {
+    width: 28px;
+    height: 28px;
+    display: block;
+    transition: filter 0.3s ease;
+  }
+
+  .social-share-wrapper .links a::after {
+    content: attr(title);
+    position: absolute;
+    bottom: 110%;
+    left: 50%;
+    background-color: #495057;
+    color: #fff;
+    padding: 0.3rem 0.7rem;
+    border-radius: 5px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    transform: translateX(-50%) translateY(4px);
+  }
+
+  .social-share-wrapper .links a:hover::after {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 </style>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,8 +15,8 @@ layout: page
 
           {% capture linkedin_url %}https://www.linkedin.com/shareArticle?mini=true&url={{ site.url | append: page.url |
           url_encode }}&summary={{ page.title | url_encode }}{% endcapture %}
-          <a href="{{ linkedin_url }}" target="_blank" rel="noopener" title="Share on LinkedIn"
-            data-tooltip="Share on LinkedIn">
+          <a href="{{ linkedin_url }}" target="_blank" rel="noopener" aria-label="Share on LinkedIn"
+            data-share-tooltip="Share on LinkedIn">
             <img src="{{ '/assets/images/logos/linkedin-dark.svg' | relative_url }}"
               data-logo-for-dark="{{ '/assets/images/logos/linkedin-light.svg' | relative_url }}"
               data-logo-for-light="{{ '/assets/images/logos/linkedin-dark.svg' | relative_url }}" alt="LinkedIn logo"
@@ -26,8 +26,8 @@ layout: page
 
           {% capture twitter_url %}https://x.com/intent/tweet?text={{ page.title | url_encode }}&url={{ site.url |
           append: page.url | url_encode }}&hashtags=meshery&via=mesheryio{% endcapture %}
-          <a href="{{ twitter_url }}" target="_blank" rel="noopener" title="Share on Twitter/X"
-            data-tooltip="Share on Twitter/X">
+          <a href="{{ twitter_url }}" target="_blank" rel="noopener" aria-label="Share on Twitter/X"
+            data-share-tooltip="Share on Twitter/X">
             <img src="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}"
               data-logo-for-dark="{{ '/assets/images/logos/twitter-light.svg' | relative_url }}"
               data-logo-for-light="{{ '/assets/images/logos/twitter-dark.svg' | relative_url }}" alt="Twitter logo"
@@ -37,8 +37,8 @@ layout: page
           {% capture bluesky_text %}{{ page.title }} by @mesheryio.bsky.social {{ site.url | append: page.url }}{% if
           page.tags %} {% for tag in page.tags %}#{{ tag | replace: ' ', '' }} {% endfor %}{% endif %}{% endcapture %}
           {% capture bluesky_url %}https://bsky.app/intent/compose?text={{ bluesky_text | url_encode }}{% endcapture %}
-          <a href="{{ bluesky_url }}" target="_blank" rel="noopener" title="Share on Bluesky"
-            data-tooltip="Share on Bluesky">
+          <a href="{{ bluesky_url }}" target="_blank" rel="noopener" aria-label="Share on Bluesky"
+            data-share-tooltip="Share on Bluesky">
             <img src="{{ '/assets/images/logos/bluesky-dark.svg' | relative_url }}"
               data-logo-for-dark="{{ '/assets/images/logos/bluesky-dark.svg' | relative_url }}"
               data-logo-for-light="{{ '/assets/images/logos/bluesky-light.svg' | relative_url }}" alt="Bluesky Logo"
@@ -100,7 +100,7 @@ layout: page
   }
 
   .social-share-wrapper .links a::after {
-    content: attr(title);
+    content: attr(data-share-tooltip);
     position: absolute;
     bottom: 110%;
     left: 50%;


### PR DESCRIPTION
**Description**
This PR fixes #2711 

Added hover animation and CSS tooltips to the social share icons (LinkedIn, Twitter/X, Bluesky) on individual blog post pages.



https://github.com/user-attachments/assets/6a10affa-3d75-4c66-a494-9f62fb791bc4




**Changes made:**
- `_layouts/post.html` — added CSS for hover lift, scale, and glow effect on social share icons
- Added `data-tooltip` attribute to each social share `<a>` tag (LinkedIn, Twitter/X, Bluesky) for consistent tooltip behavior

**Notes for Reviewers**
The tooltip uses the existing `title` attribute already present on each `<a>` tag, so no HTML changes were needed — CSS only.
Hover animation uses Meshery's brand color (rgba(0, 179, 159, 0.35)) for the glow effect, consistent with the site's color scheme.


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
