### PR TITLE
[CI] Recreate Discussion Forum data sync workflow

### DIFF
--- a/.github/workflows/discussions-data-files-update.yml
+++ b/.github/workflows/discussions-data-files-update.yml
@@ -1,0 +1,36 @@
+name: Discussion data files update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' #runs every day at midnight
+
+permissions:
+  contents: write
+jobs:
+  update:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'meshery/meshery.io'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Fetch data for meshery tag
+        run: |
+          mkdir -p _data/discuss
+          curl -L https://discuss.meshery.io/tag/meshery.json -o _data/discuss/meshery.json
+
+      - name: Pull changes from remote
+        run: git pull origin master
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          file_pattern: _data/discuss/*.json
+          commit_user_name: Discussions bot
+          commit_user_email: discussions@meshery.io
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          commit_options: "--signoff"
+          commit_message: "latest discussion data files added"
+          branch: master


### PR DESCRIPTION
**Notes for Reviewers**

Recreates the daily "Discussion data files update" workflow that was removed in #2696. It fetches Discourse topic data into `_data/discuss/meshery.json`, which the `related-discussion` and `popular-discuss-posts` includes still read via `site.data.discuss.meshery`. Without it, those includes render with no recent threads.

Changes from the removed version:

- Fetches from `https://discuss.meshery.io/tag/meshery.json`.
- Writes to `_data/discuss/meshery.json`. The original wrote to `docs/_data/discuss/meshery.json`, which is the wrong path for this Jekyll site, so the synced file never landed where the includes read it.
- Adds `mkdir -p _data/discuss` before the `curl -o` so the output path exists.
- Scopes the auto-commit to `_data/discuss/*.json`.

Runs on a daily schedule and on manual dispatch, guarded to `meshery/meshery.io` only.

Removed in: #2696
