### PR TITLE
[Programs] Fix popular discussion links pointing to dead anchor

### DIFF
--- a/_includes/popular-discuss-posts.html
+++ b/_includes/popular-discuss-posts.html
@@ -14,7 +14,7 @@
     <!-- -->
     <li class="post">
       <span class="post-date"> {{ post.created_at | date: " %Y %b %d " }}| </span>
-      <a href="{{ '/community#discussion-forums/t/' | append: post.topics[0].slug | append: '/' | append: post.id | relative_url }}"> {{ post.title }}</a>
+      <a href="https://discuss.meshery.io/t/{{ post.slug }}/{{ post.id }}" target="_blank" rel="noopener"> {{ post.title }}</a>
       <span class="post-author" id="{{ post.id }}"> 
         {% for user in users %}
           {% if post.posters[0].user_id == user.id %}


### PR DESCRIPTION
**Notes for Reviewers**

The "Most popular Discussions" list on the `/programs` page rendered links that went nowhere. Clicking any topic landed on `/community` instead of opening the thread, and the URL looked like `https://meshery.io/community#discussion-forums/t//7737` (note the empty slug between the double slash).

Two separate defects:

1. **Wrong destination.** The link pointed to `/community#discussion-forums/t/<slug>/<id>`. That `#discussion-forums` fragment is only an anchor to the static "Discussion Forums" section on the community page. There is no routing that parses the `/t/<slug>/<id>` part, so the browser found no matching element and stayed on `/community`.
2. **Empty slug.** The slug was read from `post.topics[0].slug`. Discourse topic objects expose the slug directly as `post.slug` and have no nested `topics` array, so that segment was always empty, producing `.../t//<id>`.

**Fix**

Point the links at the canonical Discourse topic URL using `post.slug`:

```liquid
<a href="https://discuss.meshery.io/t/{{ post.slug }}/{{ post.id }}" target="_blank" rel="noopener">{{ post.title }}</a>
```

For topic 7737 this now resolves to `https://discuss.meshery.io/t/shape-builder-extension-seeking-contributors-to-become-maintainers/7737`, a real thread.

**When this started**

The dead-anchor destination was introduced in `011a66782` ("move discuss links to community page", Feb 6 2025), which changed the href from `http://discuss.meshery.io/t/...` to `/community#discussion-forums/t/...`. Before that the link went straight to Discourse, which resolves a topic by its ID even when the slug is wrong or missing, so the empty-slug issue (present since the feature was added in 2023) was harmless.

**Why it is only surfacing now**

The popular discussions block on `/programs` was empty for the recent period: the data file `_data/discuss/meshery.json` was deleted in a catalog refresh and the sync workflow was removed in #2696. The workflow was recreated in #2734 and ran on Jun 17 2026, repopulating the data. With links rendering again, the broken destination became visible.

Note: `_includes/related-discussion.html` carries the same two defects, but it is currently wrapped in `{% if false %}` and does not render, so it is left untouched here.
