### PR TITLE
fix(extensions): update TCS Labs Academy logo references

### DIFF
--- a/collections/_extensions/tcslabs-academy.md
+++ b/collections/_extensions/tcslabs-academy.md
@@ -8,9 +8,9 @@ type: Collaboration
 compatibility:
   - meshery
 extensionId: deea6061-b6be-49a9-ad1c-f1a5c32e1fa9
-logo: /assets/images/extensions/meshery-academy.svg
-whiteImage: /assets/images/extensions/meshery-academy.svg
-colorImage: /assets/images/extensions/meshery-academy.svg
+logo: /assets/images/extensions/tcslabs-academy.svg
+whiteImage: /assets/images/extensions/tcslabs-academy.svg
+colorImage: /assets/images/extensions/tcslabs-academy.svg
 
 extensionInfo: |
   TCS Labs Academy is the official learning-content repository for TCS Labs on the Meshery Academy platform. It hosts structured learning paths, challenges, certifications, and Meshery infrastructure designs.


### PR DESCRIPTION
## Description

Fixes #2746

The TCS Labs Academy extension was still referencing the generic Meshery Academy logo even though a dedicated TCS Labs Academy logo asset exists.

This PR updates the following fields in `collections/_extensions/tcslabs-academy.md`:

* `logo`
* `whiteImage`
* `colorImage`

to use:

`/assets/images/extensions/tcslabs-academy.svg`

instead of:

`/assets/images/extensions/meshery-academy.svg`

## Validation

* Verified `tcslabs-academy.svg` exists.
* Verified only one file was modified.
* Verified only the three logo reference lines changed.
* Verified `meshery-academy.md` remains unchanged.
* Verified commit includes DCO signoff.

**Signed commits**

* [x] Yes, I signed my commits.
