### PR TITLE
fix:update-community-discussion-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [![GitHub issues by-label](https://img.shields.io/github/issues/meshery/meshery/help%20wanted.svg)](https://github.com/issues?q=is%3Aopen%20is%3Aissue%20archived%3Afalse%20(org%3Ameshery%20OR%20org%3Aservice-mesh-performance%20OR%20org%3Aservice-mesh-patterns%20OR%20org%3Ameshery-extensions)%20label%3A%22help%20wanted%22)
 [![Website](https://img.shields.io/website/https/meshery.io/meshery.svg)](https://meshery.io/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/mesheryio)](https://twitter.com/intent/follow?screen_name=mesheryio)
-[![Discuss Users](https://img.shields.io/discourse/users?server=https%3A%2F%2Fdiscuss.meshery.io)](https://meshery.io/community#discussion-forums)
+[![Discuss Users](https://img.shields.io/discourse/users?server=https%3A%2F%2Fdiscuss.meshery.io)](https://discuss.meshery.io)
 [![Slack](https://img.shields.io/badge/Slack-@meshery.svg?logo=slack)](https://slack.meshery.io)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3564/badge)](https://bestpractices.coreinfrastructure.org/projects/3564)
 
@@ -82,7 +82,7 @@ Find out more about the <a href="https://meshery.io/community">Meshery community
 ✔️ <em><strong>Join</strong></em> any or all of the weekly meetings on the <a href="https://meshery.io/calendar">community calendar</a>.<br />
 ✔️ <em><strong>Watch</strong></em> community <a href="https://www.youtube.com/@mesheryio?sub_confirmation=1">meeting recordings</a>.<br />
 ✔️ <em><strong>Access</strong></em> the <b>Community Drive</b>-by completing a community <a href="https://meshery.io/newcomer">Member Form</a>.<br />
-✔️ <em><strong>Discuss</strong></em> in the <a href="https://meshery.io/community#discussion-forums">Community Forum</a>.<br />
+✔️ <em><strong>Discuss</strong></em> in the <a href="https://discuss.meshery.io">Community Forum</a>.<br />
 ✔️ <em><strong>RSVP</strong></em> to the <a href="https://community.cncf.io/meshery-community/">CNCF Meshery Community</a> meetings.<br />
 </p>
 <p align="center">

--- a/_includes/newcomers-contribute-guide.html
+++ b/_includes/newcomers-contribute-guide.html
@@ -82,7 +82,7 @@
                 <li>Contributions of all sizes are welcome.</li>
                 <li>
                     If you need some additional help, please join Meshery community discussions in the
-                    <a href="https://meshery.io/community#discussion-forums" rel="noreferrer">discussion
+                    <a href="https://discuss.meshery.io" rel="noreferrer">discussion
                         forum</a>
                     or find your way to the
                     <a href="https://slack.meshery.io" target="_blank" rel="noreferrer">#newcomers</a>
@@ -127,7 +127,7 @@
                 small number of maintainers/reviewers. All contributors are
                 equally important to us, and we'll be sure to get to you as soon
                 as possible. In the meanwhile, you are welcome to engage in the Meshery community by asking questions in a
-                <a href="https://meshery.io/community#discussion-forums/" target="_blank" rel="noreferrer">discussion
+                <a href="https://discuss.meshery.io/" target="_blank" rel="noreferrer">discussion
                     forum</a>, and join our
                 <a href="https://slack.meshery.io/" target="_blank" rel="noreferrer">Slack workspace</a>.
             </p>

--- a/_includes/related-discussion.html
+++ b/_includes/related-discussion.html
@@ -22,7 +22,7 @@
     <!-- -->
     <li class="post">
       <span class="post-date"> {{ post.created_at | date: "%b %d" }} | </span>
-      <a href="https://meshery.io/community#discussion-forums/t/{{ post.topics[0].slug }}/{{ post.id }}"> {{ post.title }}</a>
+      <a href="https://discuss.meshery.io/t/{{ post.topics[0].slug }}/{{ post.id }}"> {{ post.title }}</a>
       <span id="author" class="post-author"> 
         {%for user in users%}
         {% if(post.posters[0].user_id == user.id)%}

--- a/collections/_pages/community-newcomers.html
+++ b/collections/_pages/community-newcomers.html
@@ -185,7 +185,7 @@ title: A dedicated page for the newcomers
             actively engage in the development of projects at Meshery. Here are some instructions to get you started and
             if you haven’t joined yet, join the
             <a href="https://slack.meshery.io/" target="_blank" rel="noopener noreferrer">Slack workspace</a>
-            to collaborate with the community and a <a href="https://meshery.io/community#discussion-forums rel="noopener noreferrer">discussion forum</a>
+            to collaborate with the community and a <a href="https://discuss.meshery.io rel="noopener noreferrer">discussion forum</a>
             for questions. Also, you can check the
             quick-links below for jumping straight into things.
         </p>

--- a/collections/_pages/community-newcomers.html
+++ b/collections/_pages/community-newcomers.html
@@ -185,7 +185,7 @@ title: A dedicated page for the newcomers
             actively engage in the development of projects at Meshery. Here are some instructions to get you started and
             if you haven’t joined yet, join the
             <a href="https://slack.meshery.io/" target="_blank" rel="noopener noreferrer">Slack workspace</a>
-            to collaborate with the community and a <a href="https://discuss.meshery.io rel="noopener noreferrer">discussion forum</a>
+            to collaborate with the community and a <a href="https://discuss.meshery.io" rel="noopener noreferrer">discussion forum</a>
             for questions. Also, you can check the
             quick-links below for jumping straight into things.
         </p>

--- a/collections/_posts/2025/02/2025-02-01-ninth-highest-velocity-cncf-project.md
+++ b/collections/_posts/2025/02/2025-02-01-ninth-highest-velocity-cncf-project.md
@@ -74,7 +74,7 @@ Thank you to every contributor, user, and community member for making Meshery th
 Meshery's success is a collective effort, driven by the passion and dedication of its community members. We encourage everyone to get involved and contribute to this exciting project. Whether you're a seasoned developer or just starting your cloud-native journey, there's a place for you in the Meshery community.
 
 * Contribute to the [project on GitHub](https://github.com/meshery)
-* Join the community discussions: [Slack](https://slack.meshery.io), [Forum](https://meshery.io/community#discussion-forums)
+* Join the community discussions: [Slack](https://slack.meshery.io), [Forum](https://discuss.meshery.io)
 * Share your insights and experiences on the [Meshery blog](https://meshery.io/blog)
 
 Let's continue to propel Meshery forward and shape the future of cloud-native infrastructure management!

--- a/collections/_posts/2025/09/30/2025-09-30-navigating-hacktoberfest-2025.md
+++ b/collections/_posts/2025/09/30/2025-09-30-navigating-hacktoberfest-2025.md
@@ -49,7 +49,7 @@ Respect, collaboration, and kindness are the bedrock of Open Source. The Code of
 
 ### 5. Engaging Beyond Code: Fostering Holistic Development
 
-Don't confine yourself to a GitHub profile. Engage in meaningful discussions, participate in webinars, and [open discussions](https://meshery.io/community#discussion-forums). Be a mentor and seek mentorship. Open Source offers a wealth of opportunities for comprehensive growth. While coding skills undoubtedly benefit, the real lessons often lie in understanding people and their diverse perspectives.
+Don't confine yourself to a GitHub profile. Engage in meaningful discussions, participate in webinars, and [open discussions](https://discuss.meshery.io). Be a mentor and seek mentorship. Open Source offers a wealth of opportunities for comprehensive growth. While coding skills undoubtedly benefit, the real lessons often lie in understanding people and their diverse perspectives.
 
 ### 6. Compassion Over Code: Recognizing Maintainer Burnout
 

--- a/collections/_posts/2025/11/04/2025-11-04-meshery-extensions-org.md
+++ b/collections/_posts/2025/11/04/2025-11-04-meshery-extensions-org.md
@@ -88,7 +88,7 @@ Support expectations differ between the core platform and extensions to reflect 
 ### User Guidance
 
 * **Documentation**: Both core and extension documentation should be accessible, with clear instructions on installation, usage, and troubleshooting.  
-* **Community Channels**: Users can seek help via [Slack](https://slack.meshery.io), GitHub issues, or the [discussion forum](https://meshery.io/community#discussion-forums).
+* **Community Channels**: Users can seek help via [Slack](https://slack.meshery.io), GitHub issues, or the [discussion forum](https://discuss.meshery.io).
 
 ## Project Mechanics
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the community discussion forum link by replacing the [old URL](http://meshery.io/community#discussion-forums) with https://discuss.meshery.io.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
