### PR TITLE
chore: add self-paced contributor training links to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-new-pattern.md
+++ b/.github/ISSUE_TEMPLATE/add-new-pattern.md
@@ -23,3 +23,4 @@ Add or update the following [Meshery Catalog](https://meshery.io/catalog) item(s
 The meshery.io website uses Jekyll and GitHub Pages. Site content is found under the [`master` branch](https://github.com/meshery/meshery.io/tree/master).
 - See the [Contributing to Meshery.io Website](https://github.com/meshery/meshery.io#contributing-to-the-mesheryio-website) section of the readme.md and other [contributing instructions](https://docs.meshery.io/project/contributing), too.
 - See Meshery site designs in this [Figma designfile](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI?node-id=110%3A1). Fill-in the [Community Member Form](https://meshery.io/newcomer) and join the [Community Slack](https://slack.meshery.io) for access.
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/blog.md
+++ b/.github/ISSUE_TEMPLATE/blog.md
@@ -23,3 +23,4 @@ Contributors and community members are encouraged to post on https://meshery.io/
 The meshery.io website uses Jekyll and GitHub Pages. Site content is found under the [`master` branch](https://github.com/meshery/meshery.io/tree/master).
 - See [contributing instructions] (https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md)
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,3 +29,4 @@ The meshery.io website uses Jekyll and GitHub Pages. Site content is found under
 - 📚 See the [Contributing to Meshery.io Website](https://github.com/meshery/meshery.io#contributing-to-the-mesheryio-website) section of the readme.md and other [contributing instructions](https://docs.meshery.io/project/contributing), too.
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](/community#discussion-forums) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -15,3 +15,4 @@ assignees: ''
 - [Meshery documentation site](https://docs.meshery.io)
 - [Meshery documentation source](https://github.com/meshery/meshery/tree/master/docs)
 - [Instructions for contributing to documentation](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,3 +23,4 @@ assignees: ''
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🖥 [Contributing to Meshery Website](https://github.com/meshery/meshery.io#contributing-to-the-mesheryio-website)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](/community#discussion-forums) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/site_update.md
+++ b/.github/ISSUE_TEMPLATE/site_update.md
@@ -18,3 +18,4 @@ The meshery.io website uses Jekyll and GitHub Pages. Site content is found under
 - 📚 See the [Contributing to Meshery.io Website](https://github.com/meshery/meshery.io#contributing-to-the-mesheryio-website) section of the readme.md and other [contributing instructions](https://docs.meshery.io/project/contributing), too.
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](/community#discussion-forums) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)


### PR DESCRIPTION
This PR addresses issue #2799 by adding the "Self-paced Contributor Trainings" resource link to the contributor resources section in 6 issue templates (`add-new-pattern`, `blog`, `bug_report`, `documentation`, `feature_request`, `site_update`). 

Fixes #2799
