### PR TITLE
feat(catalog): publish DigitalOcean icons sample design to catalog

### DIFF
--- a/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml
+++ b/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml
@@ -1,0 +1,85 @@
+{
+  "id": "d0cc730d-2c44-4235-acb7-688f5e99750d",
+  "name": "DigitalOcean Icons Design",
+  "version": "0.0.1",
+  "components": [
+    {
+      "id": "e0aa730d-2c44-4235-acb7-688f5e99750d",
+      "model": {
+        "name": "digitalocean-icons",
+        "version": "v1.0.0",
+        "displayName": "DigitalOcean Icons",
+        "metadata": {
+          "isAnnotation": true,
+          "primaryColor": "#0080FF",
+          "secondaryColor": "#0069D9",
+          "shape": "circle"
+        }
+      },
+      "format": "JSON",
+      "status": "enabled",
+      "styles": {
+        "shape": "circle",
+        "primaryColor": "#0080FF",
+        "secondaryColor": "#0069D9",
+        "position": {
+          "x": 100,
+          "y": 100
+        }
+      },
+      "version": "v1.0.0",
+      "metadata": {
+        "isAnnotation": true,
+        "isNamespaced": false,
+        "published": true
+      },
+      "component": {
+        "kind": "digitalocean",
+        "schema": "",
+        "version": ""
+      },
+      "description": "DigitalOcean Logomark Icon",
+      "displayName": "digitalocean-icon-1"
+    },
+    {
+      "id": "e0ab730d-2c44-4235-acb7-688f5e99750d",
+      "model": {
+        "name": "digitalocean-icons",
+        "version": "v1.0.0",
+        "displayName": "DigitalOcean Icons",
+        "metadata": {
+          "isAnnotation": true,
+          "primaryColor": "#0080FF",
+          "secondaryColor": "#0069D9",
+          "shape": "circle"
+        }
+      },
+      "format": "JSON",
+      "status": "enabled",
+      "styles": {
+        "shape": "circle",
+        "primaryColor": "#0080FF",
+        "secondaryColor": "#0069D9",
+        "position": {
+          "x": 250,
+          "y": 100
+        }
+      },
+      "version": "v1.0.0",
+      "metadata": {
+        "isAnnotation": true,
+        "isNamespaced": false,
+        "published": true
+      },
+      "component": {
+        "kind": "digitalocean-logo",
+        "schema": "",
+        "version": ""
+      },
+      "description": "DigitalOcean Full Wordmark Logo",
+      "displayName": "digitalocean-logo-1"
+    }
+  ],
+  "relationships": [],
+  "schemaVersion": "designs.meshery.io/v1beta1"
+}

--- a/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
+++ b/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
@@ -1,0 +1,20 @@
+---
+layout: item
+name: DigitalOcean Icons Design
+publishedVersion: 0.0.1
+userId: 637f0d76-d582-4269-a08c-e85e6e5e2312
+userName: Olaleye Oyewunmi
+userAvatarURL: 
+type: workloads
+compatibility:
+    - digitalocean-icons
+patternId: d0cc730d-2c44-4235-acb7-688f5e99750d
+image: /assets/images/logos/service-mesh-pattern.svg
+patternInfo: |
+  A simple design pattern showcasing the standalone icon and full wordmark logo for DigitalOcean whiteboard annotations.
+patternCaveats: |
+  Requires the digitalocean-icons model registered.
+permalink: catalog/workloads/digitalocean-icons-design-d0cc730d-2c44-4235-acb7-688f5e99750d.html
+URL: 'https://raw.githubusercontent.com/meshery/meshery.io/master/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml'
+downloadLink: d0cc730d-2c44-4235-acb7-688f5e99750d/design.yml
+---


### PR DESCRIPTION
### Description

This PR registers a sample design containing the new DigitalOcean annotation components (`digitalocean` logomark and `digitalocean-logo` wordmark) to the Meshery Integration Catalog.

### Changes
- Added `catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml`
- Added Jekyll metadata page `catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md`

### Links
Companion PR to meshery/meshery#20875.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new DigitalOcean Icons catalog entry.
  * Added DigitalOcean logomark and wordmark components with branded styling and positioning.
  * Included catalog metadata, preview imagery, download references, and design specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->