### PR TITLE
fix: update Helm Snapshot documentation link

### DIFF
--- a/collections/_extensions/helm-kanvas-snapshot.md
+++ b/collections/_extensions/helm-kanvas-snapshot.md
@@ -24,5 +24,5 @@ extensionCaveats: |
   - Seamless Integration: Leverages Meshery Cloud and GitHub Actions to handle snapshot rendering.
   - Support for Packaged Charts: Works with both packaged .tar.gz charts and unpackaged Helm charts.
 
-docsURL: 'https://docs.meshery.io/extensions/helm-kanvas-snapshot'
+docsURL: https://docs.meshery.io/extensions/extensions/helm-snapshot/
 ---


### PR DESCRIPTION
Description:

## Description

Fixed the broken "Learn More" link for the Helm Plugin for Kanvas Snapshot extension.

## Changes Made

- Updated the `docsURL` in `collections/_extensions/helm-kanvas-snapshot.md`
- Changed the link from the outdated URL to the correct documentation page:

https://docs.meshery.io/extensions/extensions/helm-snapshot/

## Testing

- Ran Meshery.io locally using Jekyll
- Verified the Extensions page loads correctly
- Confirmed that the "Learn More" button redirects to the correct Helm Snapshot documentation page

## Related Issue

Fixes #2818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Helm Snapshot extension documentation link to the current documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->