### PR TITLE
fix: resolve broken DigitalOcean Icons image in compatibility section

### DIFF
--- a/_includes/partials/compatibility.html
+++ b/_includes/partials/compatibility.html
@@ -48,6 +48,8 @@
     <img class="service-mesh-image" src="{{site.baseurl}}/assets/images/integration/keda-http-scaler/icons/color/keda-http-scaler-color.svg" />
     {% elsif item == "wordpress-operator" %}
     <img class="service-mesh-image" src="{{site.baseurl}}/assets/images/integration/wordpress-operator/icons/color/wordpress-operator-color.svg" />
+    {% elsif item == "digitalocean-icons" %}
+    <img class="service-mesh-image" src="{{site.baseurl}}/assets/images/integration/digitalocean-icons/icons/color/digitalocean-icons-color.svg" />
     {% else %}
         <img class="service-mesh-image" src="{{site.baseurl}}/images/integrations/{{ item | downcase | replace: ' ', '-'  }}/icons/color/{{ item | downcase | replace: ' ', '-'  }}-color.svg" />
     {% endif %}


### PR DESCRIPTION
## Description
Adds an explicit `digitalocean-icons` case to `_includes/partials/compatibility.html` to fix the broken compatibility image on the [DigitalOcean Icons Showcase](https://meshery.io/catalog/deployment/digitalocean-icons-showcase-574aecfa-2aa4-4a8e-b88a-cc8397734f33.html) design page.
The `digitalocean-icons` compatibility entry was falling into the generic `else` branch which constructs an incorrect image path (`/images/integrations/...`). The correct path is under `/assets/images/integration/digitalocean-icons/icons/color/` as generated by the CI pipeline.


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying DigitalOcean-specific icons in compatibility information.
  * Compatibility entries using the DigitalOcean icon type now render the appropriate image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->