### PR TITLE
fix: persist theme toggle icon state across page navigation

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -155,13 +155,30 @@
 		});
 	}
 
+	// Keep the control's icon aligned with the stored theme on initial load
+	// and after a user changes the mode.
+	function syncToggleIcon() {
+		const toggleIcon = toggleBtn.querySelector("img");
+		if (!toggleIcon) return;
+		const storedMode = localStorage.getItem("mode");
+		toggleIcon.src = storedMode === "light-mode"
+			? toggleIcon.dataset.logoForLight
+			: toggleIcon.dataset.logoForDark;
+	}
+
+	syncToggleIcon();
+
 	function setMode() {
 		document.body.classList.toggle("dark-mode")
-		
+
+		const baseUrl = window.siteBaseUrl || "";
+		let l5Logos = document.querySelectorAll("#l5-logo");
 		let allLogos = document.querySelectorAll("#logo-dark-light, .logo-dark-light");
 		if (document.body.classList.contains("dark-mode")) {
+			l5Logos.forEach(e => e.src = baseUrl + '/assets/images/company-logo/dark-mode-logo.svg')
 			allLogos.forEach(e => e.src = e.dataset.logoForDark)
 		} else {
+			l5Logos.forEach(e => e.src = baseUrl + '/assets/images/company-logo/no-trim.svg')
 			allLogos.forEach(e => e.src = e.dataset.logoForLight)
 		}
 		if (document.body.classList.contains("dark-mode")) {
@@ -169,6 +186,7 @@
 		} else {
 			localStorage.setItem("mode", "light-mode")
 		}
+		syncToggleIcon();
 		document.dispatchEvent(new CustomEvent("themeChange",{
 			detail : {value : localStorage.getItem("mode")},
 			bubbles: true ,


### PR DESCRIPTION
## Description

Fixes theme toggle icon failing to reflect stored preference when navigating between pages.

## Root cause

`header.html` correctly restores the `dark-mode` body class from `localStorage` on every page load. However, the toggle button's icon (`moon` / `sun`) was never synced to the stored value — it always rendered the moon image on load regardless of what the user had selected. On sub-pages like `/docs` and `/catalog`, users would see the correct background colour (dark or light) but the wrong toggle icon, making the control appear broken.

A second issue: `setMode()` used a hardcoded relative path `../assets/...` for the Layer5 logo swap, which resolves incorrectly on sub-pages.

## Changes

**`_includes/footer.html`**
- Add a `syncToggleIcon()` IIFE that runs immediately after the toggle button is wired up — reads `localStorage` and sets the correct sun/moon icon on every page load
- Replace `../assets/...` relative paths in `setMode()` with `window.siteBaseUrl` (already set by `header.html`) so logo swaps work correctly on `/docs`, `/catalog`, and all other sub-pages

## Testing

1. Go to `https://meshery.io/`
2. Switch to Light Mode using the toggle
3. Navigate to **Docs** or **Catalog**
4. **Before fix:** sun icon resets to moon; **After fix:** sun icon persists correctly
5. Refresh on a sub-page — theme and icon both restore from `localStorage`

Closes #2785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme toggle behavior so its icon correctly reflects the selected light or dark mode when pages load and after switching modes.
  * Fixed the primary logo’s light and dark assets not loading correctly on sites hosted under different base URLs.
  * Ensured theme-aware branding updates consistently when the display mode changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->