### PR TITLE
[Catalog] Soften filter count badge and checkbox contrast on side panel

### DIFF
--- a/_includes/patterns-filter.html
+++ b/_includes/patterns-filter.html
@@ -98,10 +98,12 @@
   #cardpatterntype-div .badge {
     background: var(--color-primary-dark);
     border: 1px solid var(--color-primary-extra-dark);
-    border-radius: 50%;
+    border-radius: 999px;
     color: var(--color-secondary-dark);
     height: 20px;
-    width: 20px;
+    min-width: 20px;
+    padding: 0 6px;
+    box-sizing: border-box;
     text-align: center;
     flex-shrink: 0;
     font-size: 12px;

--- a/_includes/patterns-filter.html
+++ b/_includes/patterns-filter.html
@@ -83,6 +83,12 @@
     cursor: pointer;
   }
 
+  #compatibility-div input[type="checkbox"],
+  #category-div input[type="checkbox"],
+  #cardpatterntype-div input[type="checkbox"] {
+    accent-color: var(--brand-color-secondary);
+  }
+
   #compatibility-div img {
     max-width: 50px;
     height: 100%;
@@ -90,9 +96,10 @@
   #compatibility-div .badge,
   #category-div .badge,
   #cardpatterntype-div .badge {
-    background: var(--color-secondary-dark);
+    background: var(--color-primary-dark);
+    border: 1px solid var(--color-primary-extra-dark);
     border-radius: 50%;
-    color: var(--color-primary-light);
+    color: var(--color-secondary-dark);
     height: 20px;
     width: 20px;
     text-align: center;
@@ -101,7 +108,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-weight: 200;
+    font-weight: 400;
   }
   #cardpatterntype-div .badge {
     padding: 2px;


### PR DESCRIPTION
**Description**

The side panel filters on the catalog content-type pages (`/catalog/designs`, `/catalog/models`, `/catalog/filters`) rendered each filter's count badge as a solid dark circle with white text. The contrast was too bold and strained the eyes. This inverts the badge styling and softens the filter checkboxes to match.

Changes (all in `_includes/patterns-filter.html`, shared by all three pages):
- **Count badge** — inverted from a solid dark fill + white text to a soft light pill (`--color-primary-dark`) with dark text (`--color-secondary-dark`) and a subtle `--color-primary-extra-dark` border. Bumped the weight from `200` to `400` so the smaller, lower-contrast number stays legible. Reads gently in both light and dark modes.
- **Filter checkboxes** — added `accent-color: var(--brand-color-secondary)` so the checked state uses the brand teal instead of the harsh browser default.

This is a CSS-only change inside an existing `<style>` block; no template/Liquid logic was touched.

**Notes for Reviewers**

The badge and checkbox styles live in one shared include, so the fix covers all three catalog pages at once. Both changes rely only on existing theme CSS variables, so they adapt automatically to light/dark mode.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

---
_Generated by [Claude Code](https://claude.ai/code/session_017rMK6qfa9xuUFxd4nZna2H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated styling for filter UI sections (compatibility, categories, and card pattern type).
  - Adjusted checkbox accent colors to match the app’s theme.
  - Refreshed badge appearance to use new theme variables, switching to a pill-style shape with improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->