### PR TITLE
[Catalog] Add sort-by-count to filter sections and differentiate single-page action buttons

### DIFF
--- a/_includes/copy-and-download.html
+++ b/_includes/copy-and-download.html
@@ -10,7 +10,7 @@
         {% if type.patternId %}
         <a href="https://playground.meshery.io/extension/meshmap?mode=design&type=catalog&id={{type.patternId}}&name={{type.name}}"
           target="_blank">
-          <button class="import" style="width: 15rem;">Open in Playground </button>
+          <button class="import import-brand-primary" style="width: 15rem;">Open in Playground </button>
         </a>
         {% endif %}
 
@@ -22,7 +22,7 @@
         {% endif %}
         <a href="{{ download_path | relative_url }}" download="{{type.name}}.yml">
           <button id="resourceDownloadBtn" data-patternId="{{type.patternId}}" onclick="sendCloudTelemetry()"
-            class="import" style="width: 7rem;">
+            class="import import-brand-secondary" style="width: 7rem;">
             Download
           </button>
         </a>
@@ -30,7 +30,7 @@
         <div class="btn-tooltip-grp">
           <a class="btn tooltip-modal" data-clipboard-target="#copy-url" data-clipboard-text="{{type.URL}}"
             onmouseout="resetCopyText(this)">
-            <button class="import" style="width: 7rem;">Copy URL
+            <button class="import import-brand-tertiary" style="width: 7rem;">Copy URL
             </button>
           </a>
         </div>

--- a/_includes/models/modal.html
+++ b/_includes/models/modal.html
@@ -79,12 +79,12 @@
               <div class="btn-grp">
                 {% if model.name %}
                 <a href="{{ '/models/' | append: model.modelFile | relative_url }}" download="{{ model.name | slugify }}.tar">
-                  <button class="import" style="width: 7rem;">Download</button></a>
+                  <button class="import import-brand-primary" style="width: 7rem;">Download</button></a>
                 {% endif %}
                 <div class="btn-tooltip-grp">
                   {% if model.name %}
                   <a href="https://docs.meshery.io/project/contributing/contributing-models-quick-start">
-                    <button class="import" style="width: 9rem;">Quick Start</button></a>
+                    <button class="import import-brand-tertiary" style="width: 9rem;">Quick Start</button></a>
                   {% endif %}
                 </div>
               </div>

--- a/_includes/patterns-filter.html
+++ b/_includes/patterns-filter.html
@@ -150,6 +150,46 @@
     font-weight: bold;
     color: var(--color-secondary-dark);
   }
+
+  .filter-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+  }
+  .sort-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--color-secondary-light);
+    background: var(--color-primary-dark);
+    border: 1px solid var(--color-primary-extra-dark);
+    border-radius: 999px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .sort-btn:hover {
+    border-color: var(--brand-color-secondary);
+    color: var(--brand-color-secondary);
+  }
+  .sort-btn:focus-visible {
+    outline: 2px solid var(--brand-color-secondary);
+    outline-offset: 1px;
+  }
+  .sort-btn.active {
+    color: var(--brand-color-secondary);
+    border-color: var(--brand-color-secondary);
+  }
+  .sort-btn .sort-arrow {
+    font-size: 10px;
+    line-height: 1;
+  }
 </style>
 
 <div class="filter-wrap">
@@ -173,11 +213,37 @@
   
   {% if show_technology=="true"%}
   <p id="compatibility-para" class="compatibility-para">
-    <strong>Technologies:</strong>
+    <span class="filter-heading">
+      <strong>Technologies:</strong>
+      <button
+        type="button"
+        class="sort-btn"
+        id="compatibility-sort"
+        data-order="none"
+        title="Sort by count"
+        aria-label="Sort technologies by count"
+      >
+        Count <span class="sort-arrow" aria-hidden="true">⇅</span>
+      </button>
+    </span>
   </p>
   <div id="compatibility-div" class="compatibility-div"></div>
   {% endif %}
-  <p id="category-para" class="category-para"><strong>Categories:</strong></p>
+  <p id="category-para" class="category-para">
+    <span class="filter-heading">
+      <strong>Categories:</strong>
+      <button
+        type="button"
+        class="sort-btn"
+        id="category-sort"
+        data-order="none"
+        title="Sort by count"
+        aria-label="Sort categories by count"
+      >
+        Count <span class="sort-arrow" aria-hidden="true">⇅</span>
+      </button>
+    </span>
+  </p>
   <div id="category-div" class="category-div" style="padding-right: 1.25rem;"></div>
 </div>
 <script>
@@ -376,6 +442,7 @@
     const count = categoryCardCount[cardType[i]];
     const inputContainer = document.createElement("div");
     inputContainer.className = "input-container";
+    inputContainer.dataset.count = count;
 
     const input = document.createElement("input");
     input.type = "checkbox";
@@ -419,6 +486,7 @@
     // Create nodes
     const inputContainer = document.createElement("div");
     inputContainer.className = "input-container";
+    inputContainer.dataset.count = count;
     // Here the categories are generated with a "checkbox" input type
     const input = document.createElement("input");
     input.type = "checkbox";
@@ -590,4 +658,76 @@ function showFilterCards() {
   
   return matchingCards.length; // Return count of matching cards
 }
+</script>
+<script>
+  // Sort-by-count controls for the Technologies and Categories filter sections.
+  // Each control cycles through three states: unsorted -> descending -> ascending.
+  // The checkbox list is built asynchronously by the module script above, so the
+  // original order and counts are read lazily on the first interaction.
+  (function () {
+    var sortSections = [
+      { key: "compatibility", container: "compatibility-div", button: "compatibility-sort" },
+      { key: "category", container: "category-div", button: "category-sort" },
+    ];
+
+    sortSections.forEach(function (section) {
+      var button = document.getElementById(section.button);
+      var container = document.getElementById(section.container);
+      // Technologies section is absent on pages that opt out (e.g. Models).
+      if (!button || !container) return;
+
+      var order = "none"; // none -> desc -> asc -> none
+      var originalOrder = null;
+
+      button.addEventListener("click", function () {
+        // Capture the as-built order once so the "none" state can restore it.
+        if (!originalOrder) {
+          originalOrder = Array.prototype.slice.call(container.children);
+        }
+        order = order === "none" ? "desc" : order === "desc" ? "asc" : "none";
+        applyOrder(container, order, originalOrder);
+        updateButton(button, order);
+      });
+    });
+
+    function applyOrder(container, order, originalOrder) {
+      if (order === "none") {
+        originalOrder.forEach(function (el) {
+          container.appendChild(el);
+        });
+        return;
+      }
+      var items = Array.prototype.slice.call(
+        container.querySelectorAll(".input-container")
+      );
+      items.sort(function (a, b) {
+        var countA = Number(a.dataset.count) || 0;
+        var countB = Number(b.dataset.count) || 0;
+        return order === "asc" ? countA - countB : countB - countA;
+      });
+      items.forEach(function (el) {
+        container.appendChild(el);
+      });
+    }
+
+    function updateButton(button, order) {
+      var arrow = button.querySelector(".sort-arrow");
+      var labelText = button.getAttribute("aria-label") || "Sort by count";
+      var baseLabel = labelText.split(" (")[0];
+      if (order === "desc") {
+        if (arrow) arrow.textContent = "▼"; // ▼
+        button.classList.add("active");
+        button.setAttribute("aria-label", baseLabel + " (high to low)");
+      } else if (order === "asc") {
+        if (arrow) arrow.textContent = "▲"; // ▲
+        button.classList.add("active");
+        button.setAttribute("aria-label", baseLabel + " (low to high)");
+      } else {
+        if (arrow) arrow.textContent = "⇅"; // ⇅
+        button.classList.remove("active");
+        button.setAttribute("aria-label", baseLabel);
+      }
+      button.setAttribute("data-order", order);
+    }
+  })();
 </script>

--- a/_sass/catalog.scss
+++ b/_sass/catalog.scss
@@ -220,6 +220,32 @@ p {
   cursor: pointer;
   padding: 10px;
 }
+
+/* Action-button variants for the single catalog item page.
+   Primary / secondary / tertiary map to the brand root colors so the
+   three actions are visually distinct; the tertiary action is outlined
+   rather than filled. */
+.import-brand-primary {
+  background-color: var(--brand-color-primary);
+}
+.import-brand-primary:hover {
+  background-color: var(--brand-color-secondary);
+}
+.import-brand-secondary {
+  background-color: var(--brand-color-secondary);
+}
+.import-brand-secondary:hover {
+  background-color: var(--brand-color-tertiary);
+}
+.import-brand-tertiary {
+  background-color: transparent;
+  color: var(--brand-color-tertiary);
+  border: 1px solid var(--brand-color-tertiary);
+}
+.import-brand-tertiary:hover {
+  background-color: var(--brand-color-tertiary);
+  color: #fff;
+}
 .btn-tooltip-grp {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
**Description**

Two catalog UX improvements:

1. **Sort-by-count for filter sections** — Adds a per-section **Count** toggle to the side-panel filters. Clicking it cycles unsorted → descending → ascending, reordering the checkbox list by each entry's count and restoring the original order on the third click. Implemented in the shared `_includes/patterns-filter.html`, so it covers:
   - **Designs** — Technologies and Categories
   - **Filters** — Technologies and Categories
   - **Models** — Categories (this page has no Technologies section)

   Each checkbox row now carries a `data-count` attribute; the sort reads it at interaction time. The setup script guards for absent sections, so the missing Technologies control on Models is a no-op rather than an error. Arrow glyph and `aria-label` update to reflect the active sort direction.

2. **Distinct action buttons on the single catalog item page** — The *Open in Playground*, *Download*, and *Copy URL* buttons all shared one fill color. They now map to the primary, secondary, and tertiary brand root colors (`--brand-color-primary`, `--brand-color-secondary`, `--brand-color-tertiary`), and the tertiary *Copy URL* action is rendered as an **outlined** button rather than filled.

**Notes for Reviewers**

- The sort control is a compact three-state toggle (unsorted / desc / asc) so both ASC and DESC are reachable and the original order can be restored.
- The sort behavior was verified in a headless Chromium run: DESC sorts high→low, ASC low→high, the third click restores the original order, and the Models case (no Technologies section) does not throw.
- Button colors use existing brand variables from `_sass/rootvariables.scss` that are stable across light and dark mode.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

---
_Generated by [Claude Code](https://claude.ai/code/session_017rMK6qfa9xuUFxd4nZna2H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added count-based sorting for the Technologies and Categories filter checkbox lists, with a toggle cycling through none → descending → ascending.
  * Included accessible sort indicators and interactive state updates (including arrow glyphs and ARIA labeling).

* **Style**
  * Updated catalog page action buttons with new brand-specific primary, secondary, and tertiary variants (including improved hover/outline behavior).
  * Applied matching brand styling across copy/download UI (including “Open in Playground”) and modal buttons (“Download” and “Quick Start”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->