### PR TITLE
[Website] Fix community calendar script loading path

### DIFF
--- a/collections/_pages/calendar.html
+++ b/collections/_pages/calendar.html
@@ -36,7 +36,7 @@ redirect_from:
 <script src="https://unpkg.com/@fullcalendar/list@4.4.0/main.min.js"></script>
 <script src="https://unpkg.com/@fullcalendar/google-calendar@4.4.0/main.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-<script src="js/calendar.js"></script>
+<script src="{{ '/js/calendar.js' | relative_url }}"></script>
 
 <style>
   .preloader {


### PR DESCRIPTION
**Description**

This PR fixes #2826 

This fixes the script loading path for the community calendar page. By wrapping `js/calendar.js` in the Jekyll `relative_url` filter, it resolves correctly to the root directory `/js/calendar.js` rather than resolving relatively to the `/calendar/` subpath. This allows the FullCalendar component to load and render properly.

[Screencast From 2026-07-24 07-52-28.webm](https://github.com/user-attachments/assets/8f082e4f-9920-410f-9612-d4048b061961)


**Notes for Reviewers**

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar script loading when the site is hosted under a configured base path.
  * Improved compatibility for deployments using custom URL prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->