### PR TITLE
Fix: make site Docker startup for local Jekyll development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,8 @@ build:
 	$(jekyll) build --drafts
 
 docker:
-	@# Run jekyll in official jekyll image without running bundle install
-	@# This avoids fetching gems on the host when Docker provides a working jekyll runtime
-	docker run --name meshery-io -d --rm -p 4000:4000 -v `pwd`:"/srv/jekyll" -w /srv/jekyll jekyll/jekyll:4 jekyll serve --drafts --livereload
+	@# Run Jekyll with the repo's Gemfile dependencies isolated in a Docker volume.
+	docker run --name meshery-io --rm -p 4000:4000 -p 35729:35729 -v "$(CURDIR)":"/srv/jekyll" -v meshery-io-bundle:"/usr/local/bundle" -w /srv/jekyll jekyll/jekyll:4 sh -lc 'bundle check || bundle install; bundle exec jekyll serve --host 0.0.0.0 --drafts --livereload --config _config_dev.yml'
 
 docker-stop:
 	docker stop meshery-io


### PR DESCRIPTION
**Description**

 PR fixes the `make site` Docker workflow for local development.

Previously, `make site` started the Jekyll container in detached mode and returned only a container ID. If the container failed during startup, the failure was hidden because the container exited and was removed immediately. The actual failure was caused by missing Gemfile dependencies inside the `jekyll/jekyll:4` image.


### This update makes the Docker target:

- run Jekyll in the foreground so startup errors are visible
- install missing bundle dependencies inside the container
- cache gems in a named Docker volume
- bind Jekyll to `0.0.0.0` so the site is reachable from the host
- expose both the site port and LiveReload port


This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Docker-based development workflow by automatically installing missing gems before starting the site.
  * Persisted installed gems between container runs for faster startup.
  * Updated the development server to be accessible from outside the container.
  * Ensured cleanup removes the development container reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->