### PR TITLE
fix: update learn more URLs and link destinations in Extensions section

### DIFF
--- a/collections/_extensions/exoscale-academy.md
+++ b/collections/_extensions/exoscale-academy.md
@@ -18,6 +18,6 @@ extensionCaveats: |
   - Includes interactive labs and guided exercises within live Exoscale environments.
   - Monitors learner progress and issues certifications upon course completion.
   - Regularly updated to include new topics on Exoscale and emerging cloud native technologies.
-URL: https://github.com/layer5io/exoscale-academy
+URL: https://exoscale.layer5.io/academy
 docsURL: https://docs.meshery.io/extensions/academies/
 ---

--- a/collections/_extensions/github-action-meshery-snapshot.md
+++ b/collections/_extensions/github-action-meshery-snapshot.md
@@ -19,5 +19,5 @@ extensionCaveats: |
   - Utilize snapshots when you need to automate your software development process using GitHub Actions.
   - Customize snapshot workflow triggers to run based on specific GitHub activities, such as creating a pull request, pushing code, or releasing a new version.
 URL: 'https://github.com/marketplace/actions/kanvas-snapshot'
-docsURL: 'https://docs.meshery.io/extensions/kanvas-snapshot'
+docsURL: 'https://docs.meshery.io/guides/infrastructure-management/gitops-with-meshery/'
 ---

--- a/collections/_extensions/helm-kanvas-snapshot.md
+++ b/collections/_extensions/helm-kanvas-snapshot.md
@@ -24,5 +24,6 @@ extensionCaveats: |
   - Seamless Integration: Leverages Meshery Cloud and GitHub Actions to handle snapshot rendering.
   - Support for Packaged Charts: Works with both packaged .tar.gz charts and unpackaged Helm charts.
 
+URL: https://github.com/meshery-extensions/helm-kanvas-snapshot
 docsURL: https://docs.meshery.io/extensions/extensions/helm-snapshot/
 ---

--- a/collections/_extensions/kanvas.md
+++ b/collections/_extensions/kanvas.md
@@ -15,6 +15,6 @@ extensionInfo: |
   Collaboratively design and manage your Kubernetes clusters and Cloud services. 
 extensionCaveats: |
   Kanvas is a visual interface for managing your infrastructure. It allows you to create, edit, and share your infrastructure as code.
-docsURL: 'https://docs.kanvas.new'
+docsURL: https://docs.meshery.io/extensions/extensions/kanvas/
 URL: 'https://www.kanvas.new'
 ---

--- a/collections/_extensions/kubectl-kanvas-snapshot.md
+++ b/collections/_extensions/kubectl-kanvas-snapshot.md
@@ -23,5 +23,4 @@ extensionCaveats: |
   - Seamless Integration: Leverages GitHub Actions to handle snapshot rendering.
   - Support for Kubernetes manifests: Works with a single manifest of a single resource, for entire namespaces, or single cluster visualizations.
 
-docsURL: 'https://docs.meshery.io/extensions/kubectl-kanvas-snapshot'
 ---

--- a/collections/_extensions/kubectl-meshsync-snapshot.md
+++ b/collections/_extensions/kubectl-meshsync-snapshot.md
@@ -21,7 +21,7 @@ extensionCaveats: |
   - Simplify Networking: Overcome common networking challenges between your infrastructure (e.g Kuberentes cluster) and your Meshery Server deployment. - Simplify Access Level Requirements: Overcome the need privileged, write access required by a full Meshery deployment, using read-only access to generate a MeshSync snapshot.
   - Snapshot Capture: Works with a single manifest of a single resource, for entire namespaces, or single cluster visualizations.
 
-docsURL: 'https://docs.meshery.io/extensions/kubectl-meshsync-snapshot'
+URL: https://github.com/meshery-extensions/kubectl-meshsync-snapshot
 ---
 
 {{ page.extensionCaveats }}

--- a/collections/_extensions/layer5-academy.md
+++ b/collections/_extensions/layer5-academy.md
@@ -19,5 +19,5 @@ extensionCaveats: |
   - Monitors learner progress and issues certifications upon course completion.
   - Regularly updated to include new topics on Layer5 and emerging cloud native technologies.
 URL: https://github.com/layer5io/layer5-academy
-docsURL: https://docs.meshery.io/extensions/academies/
+docsURL: https://docs.layer5.io/cloud/academy/
 ---

--- a/collections/_extensions/meshery-adapter-app-mesh.md
+++ b/collections/_extensions/meshery-adapter-app-mesh.md
@@ -18,5 +18,6 @@ extensionCaveats: |
   - Use the Meshery Adapter for App Mesh for lifecycle management of App Mesh and sample applications.
   - Performance testing to identify overhead involved in running App Mesh and various configurations.
   - Utilize Prometheus and Grafana integration for monitoring App Mesh's performance.
+URL: https://github.com/meshery-extensions/meshery-app-mesh
 docsURL: 'https://docs.meshery.io/extensibility/adapters/app-mesh'
 ---

--- a/collections/_extensions/meshery-adapter-nighthawk.md
+++ b/collections/_extensions/meshery-adapter-nighthawk.md
@@ -17,5 +17,6 @@ extensionCaveats: |
   - Use Meshery Adapter for Nighthawk for performance characterization and load testing of HTTP services.
   - Identify overhead and test various configurations and workloads with Meshery Adapter for Nighthawk.
   - Characterize performance and load test HTTP services with adaptive load controllers supporting HTTP/HTTPS/HTTP2 protocols.
-docsURL: 'https://docs.meshery.io/extensibility/adapters/nighthawk'
+URL: https://github.com/meshery-extensions/meshery-nighthawk
+docsURL: https://getnighthawk.dev/docs
 ---

--- a/collections/_extensions/meshery-adapter-nighthawk.md
+++ b/collections/_extensions/meshery-adapter-nighthawk.md
@@ -17,6 +17,6 @@ extensionCaveats: |
   - Use Meshery Adapter for Nighthawk for performance characterization and load testing of HTTP services.
   - Identify overhead and test various configurations and workloads with Meshery Adapter for Nighthawk.
   - Characterize performance and load test HTTP services with adaptive load controllers supporting HTTP/HTTPS/HTTP2 protocols.
-URL: https://github.com/meshery-extensions/meshery-nighthawk
+URL: https://getnighthawk.dev/
 docsURL: https://getnighthawk.dev/docs
 ---

--- a/collections/_extensions/meshery-adapter-traefik-mesh.md
+++ b/collections/_extensions/meshery-adapter-traefik-mesh.md
@@ -17,5 +17,6 @@ extensionCaveats: |
   - Use Meshery Adapter for Traefik Mesh for lifecycle management of Traefik Mesh deployments.
   - Manage Traefik Mesh lifecycle, including installation, with Meshery Adapter for Traefik Mesh.
   - Ensure existing services remain unaffected with opt-in by default until explicitly added to the mesh.
+URL: https://github.com/meshery-extensions/meshery-traefik-mesh
 docsURL: 'https://docs.meshery.io/extensibility/adapters/traefik-mesh'
 ---

--- a/collections/_extensions/shape-builder.md
+++ b/collections/_extensions/shape-builder.md
@@ -18,5 +18,5 @@ extensionCaveats: |
   - Export the format Meshery needs to recognize and render custom shapes.
   - Help teams choose or create shapes that better communicate component purpose in designs.
 URL: https://shapes.meshery.io/
-docsURL: https://docs.meshery.io/extensions/component-shape-guide
+docsURL: https://github.com/meshery-extensions/shape-builder
 ---

--- a/collections/_extensions/tcslabs-academy.md
+++ b/collections/_extensions/tcslabs-academy.md
@@ -21,5 +21,5 @@ extensionCaveats: |
   - Uses Meshery as the management plane for cloud native infrastructure learning.
 
 URL: https://github.com/meshery-extensions/tcslabs-academy
-docsURL: https://github.com/meshery-extensions/tcslabs-academy
+docsURL: https://docs.meshery.io/extensions/academies/
 ---


### PR DESCRIPTION
Fixes #2833 

### Description
This PR fixes broken or outdated "Learn More" and "Visit" links in the Extensions section of `meshery.io` to ensure they redirect to valid pages.
### Changes
1. **GitHub Action Snapshot**: Updated  docsURL  to point to the GitOps guide.
2. **TCS Labs Academy**: Updated  docsURL  to `https://docs.meshery.io/extensions/academies/`.
3. **Layer5 Academy**: Updated  docsURL  to `https://docs.layer5.io/cloud/academy/`.
4. **Nighthawk Adapter**: Added repository  URL  and updated `docsURL` to Nighthawk documentation.
5. **Kanvas**: Updated  docsURL  to extensions documentation.
6. **Shape Builder**: Updated  docsURL  to its GitHub repository.
7. **Traefik Mesh & App Mesh Adapters**: Added repository  URL  fields pointing to their GitHub pages.
8. **Kubectl MeshSync & Helm Kanvas Snapshots**: Added repository  URL  fields.
9. **Exoscale Academy**: Updated repository  URL  to `https://exoscale.layer5.io/academy`.
10. **Snapshot Kubectl Plugin**: Removed  docsURL  entirely (since it is coming soon and has no active documentation) to hide the "Learn More" button.

## Screen Recording


https://github.com/user-attachments/assets/fd23a753-bb1f-44d5-9318-0c86b563708e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated extension documentation links for Exoscale Academy, Kanvas, Layer5 Academy, Nighthawk, Shape Builder, and TCS Labs Academy.
  - Redirected GitHub Action Snapshot documentation to the Meshery GitOps infrastructure-management guide.
  - Added repository links for Helm Kanvas Snapshot, Kubectl MeshSync Snapshot, Meshery App Mesh, Nighthawk, and Traefik Mesh adapters.
  - Updated Shape Builder’s documentation link to its repository.
  - Removed the outdated documentation link for Kubectl Kanvas Snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->