### PR TITLE
fix: update broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Before contributing, please review the [Contribution Flow](https://github.com/me
   <i>If you like Meshery, please <a href="../../stargazers">★</a> star this repository to show your support! 🤩</i>
  <br />
 <a href="../../stargazers">
- <img align="center" src="https://api.star-history.com/svg?repos=meshery/meshery.io&type=Date" />
+ <img align="center" src="https://star-history.dera.page/svg?repos=meshery/meshery.io&type=Date" />
 </a></p>
 
 #### License


### PR DESCRIPTION
The Star History chart shown under the Stargazers section of the README is currently broken because the previous data source can no longer provide stargazer data without an API token. This change points the chart to an updated endpoint so the repository star history displays correctly once again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Stargazers chart to use the new image endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->