### PR TITLE
fix: correct Kanvas docs link in Shape Builder spotlight

### DIFF
--- a/collections/_posts/2026/06/28/2026-06-28-spotlight-shape-builder-extension.md
+++ b/collections/_posts/2026/06/28/2026-06-28-spotlight-shape-builder-extension.md
@@ -16,7 +16,7 @@ The Meshery ecosystem is full of focused tools that make designing and visualizi
 
 ## What is Shape Builder?
 
-[Shape Builder](https://shapes.meshery.io) is a Meshery extension that lets you visually design custom polygon shapes for use with [Kanvas](https://docs.meshery.io/extensions/kanvas/) components. Instead of hand-coding coordinate matrices, you draw a shape interactively and the tool generates the polygon notation that Meshery components understand.
+[Shape Builder](https://shapes.meshery.io) is a Meshery extension that lets you visually design custom polygon shapes for use with [Kanvas](https://docs.meshery.io/extensions/extensions/kanvas/) components. Instead of hand-coding coordinate matrices, you draw a shape interactively and the tool generates the polygon notation that Meshery components understand.
 
 That makes it a natural entry point for anyone who wants to influence how infrastructure is represented in Kanvas, the visual layer where users design and operate their cloud native deployments. Shapes carry meaning in Kanvas, as described in the [Component Shape Guide](https://docs.meshery.io/extensions/component-shape-guide/), so a better shape-authoring experience directly improves how readable a design is. The source lives at [meshery-extensions/shape-builder](https://github.com/meshery-extensions/shape-builder).
 


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Spotlight Shape Builder Extension post without observable content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->