### PR TITLE
[Chore-UI] Add Descriptive Headers to Design and Models Pages

### DIFF
--- a/_includes/partials/extension-header.html
+++ b/_includes/partials/extension-header.html
@@ -1,0 +1,7 @@
+<div>
+  <h2 class="catalog-heading">{{ include.title }}</h2>
+
+  {% if include.description %}
+    <p  class="catalog-subtext">{{ include.description }}</p>
+  {% endif %}
+</div>

--- a/_layouts/designs.html
+++ b/_layouts/designs.html
@@ -3,4 +3,9 @@ layout: plain
 ---
 
 {% assign show_technology = "true" %}
+
+{% include partials/extension-header.html
+    title="Meshery Designs"
+    description="Ready-made blueprints for common cloud native infrastructure and application architectures that save time and effort in deployment design."
+%}
 <div class="catalog">{% include patterns-filter.html %} {{content}}</div>

--- a/_layouts/filters.html
+++ b/_layouts/filters.html
@@ -3,4 +3,8 @@ layout: plain
 ---
 
 {% assign show_technology = "true" %}
+{% include partials/extension-header.html
+    title="Meshery Filters"
+    description="Pre-configured filters for Envoy proxies, WebAssembly filters, and complete application deployments."
+%}
 <div class="catalog">{% include patterns-filter.html %} {{content}}</div>

--- a/_layouts/models.html
+++ b/_layouts/models.html
@@ -3,4 +3,9 @@ layout: plain
 ---
 
 {% assign show_technology = "false" %}
+
+{% include partials/extension-header.html
+    title="Meshery Models"
+    description="Models package components and relationships providing a versioned and OCI-exportable logical representation of resources."
+%}
 <div class="catalog">{% include patterns-filter.html %} {{content}}</div>

--- a/collections/_pages/designs.html
+++ b/collections/_pages/designs.html
@@ -16,7 +16,6 @@ designs = site.catalog %}
     {% include alltype.html %}
 
     <div class="catalog-section designs-section tab-content" id="designs-tab">
-        <h2>Designs</h2>
         <div style="margin-top: 2rem;">{% include view-all.html %}</div>
         <h2 class="not-found" style="display: none;margin-top: 10rem;font-size:1.8rem" id="not-found">
             No results match your filters. Try adjusting your selections or clearing some filters.

--- a/collections/_pages/extensions.html
+++ b/collections/_pages/extensions.html
@@ -72,7 +72,10 @@ published: true
 
 {% assign extensions = extensions_by_type | concat: remaining_extensions %}
 
-
+{% include partials/extension-header.html
+  title="Meshery Extensions"
+  description="Discover extensions that expand Meshery's capabilities across cloud native infrastructure, GitOps, collaboration, and more."
+%}
 <div class="section-container">
   {% include view-all.html %} {% include extensions/card-modal.html %}
 

--- a/collections/_pages/filters.html
+++ b/collections/_pages/filters.html
@@ -34,7 +34,6 @@ permalink: /catalog/filters/
 
 
     <div class="catalog-section filters-section tab-content" id="filters-tab">
-        <h2>Filters</h2>
         <div style="margin-top: 2rem;">{% include view-all.html %}</div>
         <div class="row">
             <h2 class="not-found" style="display: none" id="not-found">


### PR DESCRIPTION
**Description**
Currently, the [desings](https://meshery.io/catalog/designs/) page, and [models](https://meshery.io/catalog/models/) pages do not have descriptive headers explaining what each page is about. This can make it difficult for new users to understand the purpose of these pages when they first visit them.
This PR adds a brief descriptive header to both pages, providing users with more context about the content available on each page.

This PR fixes #2888



**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent headers and descriptions to the Designs, Filters, Models, and Extensions pages.
  - Added explanatory content for models, filters, designs, and extensions catalogs.

- **Style**
  - Unified catalog page presentation through shared extension headers.
  - Removed redundant Designs and Filters section headings for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->