### PR TITLE
[Website] Improve design ID display and link preview metadata

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -79,6 +79,21 @@
 
 <script>
 
+	function showCopyFeedback(element, message) {
+		let wrapper = element.closest('.catalog-design-id-copy-wrapper');
+		if (!wrapper) {
+			return false;
+		}
+
+		let feedback = wrapper.querySelector('.copy-feedback');
+		feedback.textContent = message;
+		window.clearTimeout(element.copyFeedbackTimeout);
+		element.copyFeedbackTimeout = window.setTimeout(function () {
+			feedback.textContent = '';
+		}, 1500);
+		return true;
+	}
+
 	function resetCopyText(element) {
 		let childElements = element.childNodes
 		if (childElements.length > 3) {
@@ -97,18 +112,21 @@
 		console.info('Text:', e.text);
 		console.info('Trigger:', e.trigger);
 		let childElements = e.trigger.childNodes;
-		if (childElements.length > 3) {
-		childElements[3].innerHTML = "Copied!";
-	} else {
-		childElements[1].innerHTML = "Copied";
-		childElements[1].style.color = 'white';
-		childElements[1].style.background = "#1a2421";
-	}
+		if (!showCopyFeedback(e.trigger, "Copied!")) {
+			if (childElements.length > 3) {
+				childElements[3].innerHTML = "Copied!";
+			} else {
+				childElements[1].innerHTML = "Copied";
+				childElements[1].style.color = 'white';
+				childElements[1].style.background = "#1a2421";
+			}
+		}
 		e.clearSelection();
 	});
 	clipboard.on('error', function (e) {
 		console.error('Action:', e.action);
 		console.error('Trigger:', e.trigger);
+		showCopyFeedback(e.trigger, "Copy failed");
 	});
 </script>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -86,6 +86,10 @@
 		}
 
 		let feedback = wrapper.querySelector('.copy-feedback');
+		if (!feedback) {
+			return false;
+		}
+
 		feedback.textContent = message;
 		window.clearTimeout(element.copyFeedbackTimeout);
 		element.copyFeedbackTimeout = window.setTimeout(function () {

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
 				<li>
 					<h2>
 						{% if column.link %}
-						<a {% if column.new_window %}target="_blank" {% endif %} 
+						<a {% if column.new_window %}target="_blank" {% endif %}
 						href="{% include relative-src.html src=column.link %}" {% if column.social_icon
 						%}class="{{ column.social_icon | downcase }}-icon" {% endif %}>
 						{% if column.social_icon %}
@@ -32,7 +32,7 @@
 			</ul>
 			{% endfor %}
 
-			<!-- 
+			<!--
 			<ul class="feed">
 				<a class="twitter-timeline" data-width="320" data-height="320" data-theme="light"
 					data-link-color="#62ACCD" href="https://twitter.com/mesheryio"
@@ -79,24 +79,26 @@
 
 <script>
 
-	function showCopyFeedback(element, message) {
-		let wrapper = element.closest('.catalog-design-id-copy-wrapper');
-		if (!wrapper) {
-			return false;
-		}
+    // Functionality for the copy button next to the ID/UUID in Catalog Details
 
-		let feedback = wrapper.querySelector('.copy-feedback');
-		if (!feedback) {
-			return false;
-		}
+	// function showCopyFeedback(element, message) {
+	// 	let wrapper = element.closest('.catalog-design-id-copy-wrapper');
+	// 	if (!wrapper) {
+	// 		return false;
+	// 	}
 
-		feedback.textContent = message;
-		window.clearTimeout(element.copyFeedbackTimeout);
-		element.copyFeedbackTimeout = window.setTimeout(function () {
-			feedback.textContent = '';
-		}, 1500);
-		return true;
-	}
+	// 	let feedback = wrapper.querySelector('.copy-feedback');
+	// 	if (!feedback) {
+	// 		return false;
+	// 	}
+
+	// 	feedback.textContent = message;
+	// 	window.clearTimeout(element.copyFeedbackTimeout);
+	// 	element.copyFeedbackTimeout = window.setTimeout(function () {
+	// 		feedback.textContent = '';
+	// 	}, 1500);
+	// 	return true;
+	// }
 
 	function resetCopyText(element) {
 		let childElements = element.childNodes
@@ -116,21 +118,23 @@
 		console.info('Text:', e.text);
 		console.info('Trigger:', e.trigger);
 		let childElements = e.trigger.childNodes;
-		if (!showCopyFeedback(e.trigger, "Copied!")) {
-			if (childElements.length > 3) {
-				childElements[3].innerHTML = "Copied!";
-			} else {
-				childElements[1].innerHTML = "Copied";
-				childElements[1].style.color = 'white';
-				childElements[1].style.background = "#1a2421";
-			}
+        // ShowCopyFeedback serves as the primary check for the copy button in Catalog Details.
+        // If the copy button is enabled again, the conditional below needs to be encapsulate the childElements conditional
+		// if (!showCopyFeedback(e.trigger, "Copied!")) {}
+
+        if (childElements.length > 3) {
+			childElements[3].innerHTML = "Copied!";
+		} else {
+			childElements[1].innerHTML = "Copied";
+			childElements[1].style.color = 'white';
+			childElements[1].style.background = "#1a2421";
 		}
 		e.clearSelection();
 	});
 	clipboard.on('error', function (e) {
 		console.error('Action:', e.action);
 		console.error('Trigger:', e.trigger);
-		showCopyFeedback(e.trigger, "Copy failed");
+		// showCopyFeedback(e.trigger, "Copy failed");
 	});
 </script>
 
@@ -158,7 +162,7 @@
 <script type="text/javascript">
 	let toggleBtn = document.getElementById("mode-toggle-btn")
 	toggleBtn.onclick = setMode;
-	
+
 	if (localStorage.getItem("mode") === null) {
     	localStorage.setItem("mode", "dark-mode");
     }
@@ -179,7 +183,7 @@
 
 	function setMode() {
 		document.body.classList.toggle("dark-mode")
-		
+
 		let allLogos = document.querySelectorAll("#logo-dark-light, .logo-dark-light");
 		if (document.body.classList.contains("dark-mode")) {
 			allLogos.forEach(e => e.src = e.dataset.logoForDark)
@@ -196,7 +200,7 @@
 			bubbles: true ,
 		}))
 	}
-	
+
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
@@ -213,7 +217,7 @@
       slidesToScroll: 1,
       autoplay: true, // true
       autoplaySpeed: 1500,
-      
+
 
       responsive: [
         {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -47,7 +47,6 @@
     {% endif %}
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta property="twitter:title" content="Meshery" />
     <meta name="twitter:site" content="@mesheryio" />
     <meta name="twitter:creator" content="@mesheryio" />
     <meta name="author" content="Meshery Authors">

--- a/_includes/partials/individual-component.html
+++ b/_includes/partials/individual-component.html
@@ -22,8 +22,21 @@
             <div>{{pattern.type}}</div>
           </li>
 
-          <li><p>UUID</p>
-            <div>{{pattern.patternId}}</div>
+          <li><p>ID</p>
+            <div class="catalog-design-id">
+              <span class="catalog-design-id-value">{{pattern.patternId}}</span>
+              <span class="catalog-design-id-copy-wrapper">
+                <button
+                  type="button"
+                  class="btn catalog-design-id-copy"
+                  data-clipboard-text="{{pattern.patternId}}"
+                  aria-label="Copy design ID"
+                >
+                  <i class="far fa-copy" aria-hidden="true"></i>
+                </button>
+                <span class="copy-feedback" role="status"></span>
+              </span>
+            </div>
           </li>
 
           <li><p>CREATED BY</p>
@@ -105,8 +118,5 @@
   {% endif %}
 </div>
 
-<script>
-  document.title = "{{pattern.name}} | Meshery Catalog";
-</script>
 <script src="{{ site.baseurl }}/assets/js/thumbnail-clickable.js"></script>
 `

--- a/_includes/partials/individual-component.html
+++ b/_includes/partials/individual-component.html
@@ -24,12 +24,12 @@
 
           <li><p>ID</p>
             <div class="catalog-design-id">
-              <span class="catalog-design-id-value">{{pattern.patternId}}</span>
+              <span class="catalog-design-id-value">{{ pattern.patternId | escape }}</span>
               <span class="catalog-design-id-copy-wrapper">
                 <button
                   type="button"
                   class="btn catalog-design-id-copy"
-                  data-clipboard-text="{{pattern.patternId}}"
+                  data-clipboard-text="{{ pattern.patternId | escape }}"
                   aria-label="Copy design ID"
                 >
                   <i class="far fa-copy" aria-hidden="true"></i>

--- a/_includes/partials/individual-component.html
+++ b/_includes/partials/individual-component.html
@@ -22,7 +22,7 @@
             <div>{{pattern.type}}</div>
           </li>
 
-          <li><p>ID</p>
+          <!-- <li><p>ID</p>
             <div class="catalog-design-id">
               <span class="catalog-design-id-value">{{ pattern.patternId | escape }}</span>
               <span class="catalog-design-id-copy-wrapper">
@@ -37,7 +37,7 @@
                 <span class="copy-feedback" role="status"></span>
               </span>
             </div>
-          </li>
+          </li> -->
 
           <li><p>CREATED BY</p>
             <div><a href="https://cloud.meshery.io/user/{{pattern.userId}}">{{pattern.userName}}</a></div>

--- a/_plugins/catalog_page_metadata.rb
+++ b/_plugins/catalog_page_metadata.rb
@@ -1,0 +1,6 @@
+Jekyll::Hooks.register :documents, :pre_render do |document|
+  next unless document.collection&.label == "catalog"
+  next if document.data["name"].to_s.empty?
+
+  document.data["title"] = document.data["name"]
+end

--- a/_plugins/catalog_page_metadata.rb
+++ b/_plugins/catalog_page_metadata.rb
@@ -1,5 +1,6 @@
 Jekyll::Hooks.register :documents, :pre_render do |document|
   next unless document.collection&.label == "catalog"
+  next unless document.data["title"].to_s.empty?
   next if document.data["name"].to_s.empty?
 
   document.data["title"] = document.data["name"]

--- a/_plugins/catalog_page_metadata.rb
+++ b/_plugins/catalog_page_metadata.rb
@@ -1,6 +1,5 @@
 Jekyll::Hooks.register :documents, :pre_render do |document|
   next unless document.collection&.label == "catalog"
-  next unless document.data["title"].to_s.empty?
   next if document.data["name"].to_s.empty?
 
   document.data["title"] = document.data["name"]

--- a/_sass/single-page.scss
+++ b/_sass/single-page.scss
@@ -40,7 +40,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin: 0;
+  margin: 0 0.5rem 0 0;
   padding: 0.25rem;
   border: 0;
   background: transparent;
@@ -50,7 +50,7 @@
 
   &:focus-visible {
     outline: 2px solid var(--brand-color-primary);
-    outline-offset: 2px;
+    outline-offset: -1px;
   }
 }
 

--- a/_sass/single-page.scss
+++ b/_sass/single-page.scss
@@ -26,6 +26,59 @@
   }
 }
 
+.catalog-design-id {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.catalog-design-id-value {
+  overflow-wrap: anywhere;
+}
+
+.catalog-design-id-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0.25rem;
+  border: 0;
+  background: transparent;
+  color: var(--brand-color-primary);
+  font-size: 1rem;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--brand-color-primary);
+    outline-offset: 2px;
+  }
+}
+
+.catalog-design-id-copy-wrapper {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+
+  .copy-feedback {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 0.4rem);
+    z-index: 10;
+    padding: 0.3rem 0.5rem;
+    border-radius: 0.25rem;
+    background: var(--color-secondary-dark);
+    color: var(--color-primary-light);
+    font-size: 0.8rem;
+    line-height: 1;
+    white-space: nowrap;
+    pointer-events: none;
+
+    &:empty {
+      display: none;
+    }
+  }
+}
+
 .single-page code {
   padding: 1rem;
   border-radius: 0.5rem;


### PR DESCRIPTION
**Description**

Fixes #2904

- Updates the page metadata so that link previews use the design title instead of the UUID.
- Adds a Jekyll pre-render hook that assigns the catalog design name as the document title.
- Removes the duplicate hardcoded Twitter title metadata.
- Removes the client-side script that set the document title after page load.
- Removes the catalog design UUID from the details list so it is no longer surfaced in the UI.

**Notes for Reviewers**

The catalog design name is assigned as the document title during Jekyll's pre-render phase. This ensures that the generated `og:title` and `twitter:title` metadata can be read by link preview crawlers without relying on client-side JavaScript.

Tested by:

- Successfully building and serving the website with `make site`.
- Confirming that `<title>`, `og:title`, and `twitter:title` contain `vault-0.30.1.tgz` instead of the UUID.
- Confirming that the design UUID is no longer rendered on the catalog detail page.

**Signed commits**

- [x] Yes, I signed my commits.