### PR TITLE
fix(catalog): render markdown descriptions correctly

### DIFF
--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -59,10 +59,9 @@
         <h3 class="modal-h3">Description</h3>
         {% assign patternInfoLength = pattern.patternInfo | size %} {% assign
         patternCaveatsLength = pattern.patternCaveats | size %}
-        <p class="content-toggle contentdata">
-          {{pattern.patternInfo | url_decode | replace: '\\n', '<br />' |
-          replace: '\n', '<br />' }}
-        </p>
+        <div class="content-toggle contentdata">
+          {{pattern.patternInfo | url_decode | markdownify }}
+        </div>
         {% if patternInfoLength > 320 %}
         <span class="read-more" href="read-more.html"
           >{% include expand.html %}</span
@@ -71,10 +70,9 @@
       </div>
       <div class="modal-section">
         <h3 class="modal-h3">Caveats and Considerations</h3>
-        <p class="contentdata">
-          {{pattern.patternCaveats | url_decode | replace: '\\n', '<br />' |
-          replace: '\n', '<br />'}}
-        </p>
+        <div class="contentdata">
+          {{pattern.patternCaveats | url_decode | markdownify }}
+        </div>
         {% if patternCaveatsLength > 320 %}
         <span class="read-more" href="read-more.html"
           >{% include expand.html %}</span
@@ -84,19 +82,17 @@
       {% else %}
       <div class="modal-section">
         <h3 class="modal-h3">What this filter does</h3>
-        <p class="content-toggle contentdata">
-          {{pattern.filterInfo | url_decode | replace: '\\n', '<br />' |
-          replace: '\n', '<br />'}}
-        </p>
+        <div class="content-toggle contentdata">
+          {{pattern.filterInfo | url_decode | markdownify }}
+        </div>
         <span class="read-more">...read more</span>
       </div>
       <div class="modal-section">
         <h3 class="modal-h3">Caveats and Considerations</h3>
         {% assign filterCaveatsLength = pattern.patternCaveats | size %}
-        <p class="contentdata">
-          {{pattern.filterCaveats | url_decode | replace: '\\n', '<br />' |
-          replace: '\n', '<br />'}}
-        </p>
+        <div class="contentdata">
+          {{pattern.filterCaveats | url_decode | markdownify }}
+        </div>
         {% if filterCaveatsLength > 320 %}
         <span class="read-more" href="read-more.html"
           >{% include expand.html %}</span


### PR DESCRIPTION
### Description

This PR fixes the rendering aspect of #1762.
It resolves a bug causing catalog entries with rich text (e.g. "understanding persistent storage in kubernetes") to display as raw Markdown syntax on the site.

### Changes:
- Removed manual replace filters handling newlines in _includes/modal.html.
- Implemented the built-in Jekyll markdownify filter for patternInfo, patternCaveats, filterInfo, and filterCaveats.
- Changed wrapping `<p>` tags to `<div>` tags to safely contain block-level HTML generated by Kramdown and prevent premature tag-closing by browsers.
- Note: This PR does not solve missing or empty descriptions (e.g. "Kanvas Docker Extension Architecture"), as those are upstream content issues generated from the Meshery Cloud database. Please see the issue thread for details on that escalation.

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal content formatting by correctly rendering Markdown in descriptions, caveats, and filter information.
  * Preserved paragraphs, lists, and other formatted content for clearer, more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->