### PR TITLE
[UI]: Add spacing between profile photo and username on leaderboard podium cards

### DIFF
--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -431,23 +431,11 @@ body.dark-mode .period-select {
     }
 }
 
-@media (max-width: 768px) {
-
-    .leaderboard-podium {
-        gap: 1rem;
-    }
-
-    .podium-card {
-        flex: 0 0 190px;
-        max-width: 190px;
-    }
-}
-
 /* ─────────────────────────────
        MOBILE
     ───────────────────────────── */
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
 
     .leaderboard-section .leaderboard-controls {
         flex-wrap: nowrap;

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -69,7 +69,7 @@ body.dark-mode .leaderboard-filter::placeholder {
     display: flex;
     justify-content: center;
     align-items: flex-end;
-    gap: 2rem;
+    gap: 3.5rem;
     margin: 4rem 0;
     flex-wrap: wrap;
     width: 100%;
@@ -77,8 +77,8 @@ body.dark-mode .leaderboard-filter::placeholder {
 }
 
 .podium-card {
-    flex: 0 0 220px;
-    max-width: 220px;
+    flex: 0 0 290px;
+    max-width: 290px;
     display: flex;
     justify-content: center;
 }
@@ -213,7 +213,7 @@ body.dark-mode .leaderboard-filter::placeholder {
 .podium-username-link {
     text-decoration: none;
     color: inherit;
-    margin-top: 1rem;
+    margin-top: 2rem;
 }
 
 .podium-username-link:hover .podium-username {
@@ -400,10 +400,15 @@ body.dark-mode .period-select {
        TABLET
     ───────────────────────────── */
 
-@media (max-width: 768px) {
+@media (max-width: 992px) {
 
     .leaderboard-podium {
-        gap: 1rem;
+        gap: 1.5rem;
+    }
+
+    .podium-card {
+        flex: 0 0 220px;
+        max-width: 220px;
     }
 
     .podium-rank-1 .podium-avatar-wrapper {
@@ -423,6 +428,18 @@ body.dark-mode .period-select {
 
     .podium-score {
         font-size: 1.4rem;
+    }
+}
+
+@media (max-width: 768px) {
+
+    .leaderboard-podium {
+        gap: 1rem;
+    }
+
+    .podium-card {
+        flex: 0 0 190px;
+        max-width: 190px;
     }
 }
 

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -213,6 +213,7 @@ body.dark-mode .leaderboard-filter::placeholder {
 .podium-username-link {
     text-decoration: none;
     color: inherit;
+    margin-top: 1rem;
 }
 
 .podium-username-link:hover .podium-username {


### PR DESCRIPTION
**Description**

This PR improves the visual spacing and responsive behavior of the leaderboard podium cards on the Community Leaderboard page:

- **Vertical Username Spacing**: Increased `margin-top` on `.podium-username-link` from `1rem` to `2rem` to ensure clean visual separation below the rank medals, preventing badges from overlapping or sitting too close to usernames.
- **Horizontal Podium Spacing**: Increased `.leaderboard-podium` `gap` from `2rem` to `3.5rem` on desktop and expanded `.podium-card` width from `220px` to `290px`. This keeps the three podium profiles evenly distributed with comfortable breathing room and prevents longer usernames (such as `"Utkarsh-Maurya"`) from wrapping onto two lines.
- **Responsive Layout & 601px Fix**:
  - Introduced a tablet landscape rule at `@media (max-width: 992px)` with `gap: 1.5rem` and `220px` card width (combined with the existing `1.4rem` tablet font size) to prevent row wrapping on mid-sized screens.
  - Updated the mobile vertical column layout breakpoint to `@media (max-width: 768px)`, preventing the 3-column layout from overflowing or wrapping awkwardly into a second row at `601px`.

**Notes for Reviewers**

- **Desktop (`> 992px`)**: 3-column layout with `3.5rem` gap and `290px` card width. Long usernames remain on a single line at full `2.2rem` font size.
- **Tablet Landscape (`769px` – `992px`)**: 3-column layout with `1.5rem` gap and `220px` card width.
- **Tablet Portrait & Mobile (`<= 768px`)**: Clean single-column stack (`order: 1`, `order: 2`, `order: 3`) with 100% card width, eliminating the row wrapping issue at `601px`.
- Verified across multiple time periods ("This Week", "This Month", "All Time") and screen widths (1400px, 1100px, 900px, 768px, 601px, and 390px).

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

Closes #2915
