### PR TITLE
fix: use Caribbean green across leaderboard UI

### DIFF
--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -27,7 +27,7 @@
     max-width: 90%;
     padding: 0.9rem 1.4rem;
 
-    border: 2px solid var(--brand-color-secondary);
+    border: 2px solid var(--brand-color-primary);
     border-radius: 8px;
 
     font-size: 1rem;
@@ -48,7 +48,7 @@
 }
 
 .leaderboard-filter:focus-visible {
-    box-shadow: 0 0 0 3px rgba(0, 179, 159, 0.15);
+    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
 }
 
 /* Dark mode */
@@ -216,7 +216,7 @@ body.dark-mode .leaderboard-filter::placeholder {
 }
 
 .podium-username-link:hover .podium-username {
-    color: var(--brand-color-secondary);
+    color: var(--brand-color-primary);
 }
 
 .podium-username {
@@ -224,7 +224,7 @@ body.dark-mode .leaderboard-filter::placeholder {
     font-weight: 700;
     line-height: 1.1;
     text-align: center;
-    color: var(--brand-color-secondary);
+    color: var(--brand-color-primary);
     transition: color 0.2s ease;
     width: 100%;
     overflow-wrap: break-word;
@@ -268,7 +268,7 @@ body.dark-mode .podium-stat-value {
 .podium-score {
     font-size: 2rem;
     font-weight: 800;
-    color: var(--brand-color-secondary);
+    color: var(--brand-color-primary);
     line-height: 1;
 }
 
@@ -288,7 +288,7 @@ body.dark-mode .podium-stat-value {
 }
 
 .leaderboard-table thead tr {
-    background-color: var(--brand-color-secondary);
+    background-color: var(--brand-color-primary);
     color: #000000;
     text-align: left;
 }
@@ -311,7 +311,7 @@ body.dark-mode .podium-stat-value {
 }
 
 .leaderboard-table tbody tr:nth-child(even) {
-    background-color: #00B39F;
+    background-color: #00D3A9;
 }
 
 body.dark-mode {
@@ -367,11 +367,11 @@ body.dark-mode .leaderboard-updated {
     height: 35px;
     padding: 0 1rem;
 
-    border: 2px solid var(--brand-color-secondary);
+    border: 2px solid var(--brand-color-primary);
     border-radius: 8px;
 
     background: #ffffff;
-    color: var(--brand-color-secondary);
+    color: var(--brand-color-primary);
 
     font-size: 0.80rem;
     font-weight: 600;
@@ -387,7 +387,7 @@ body.dark-mode .leaderboard-updated {
 }
 
 .period-select:focus-visible {
-    box-shadow: 0 0 0 3px rgba(0, 179, 159, 0.15);
+    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
 }
 
 body.dark-mode .period-select {

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -26,8 +26,7 @@
     width: 320px;
     max-width: 90%;
     padding: 0.9rem 1.4rem;
-
-    border: 2px solid var(--brand-color-primary);
+    border: 2px solid #00B39F;
     border-radius: 8px;
 
     font-size: 1rem;
@@ -331,7 +330,6 @@ body.dark-mode {
     color: inherit;
 }
 
-
 .leaderboard-member a:hover .leaderboard-username {
     color: #000000;
     text-decoration: underline;
@@ -366,12 +364,11 @@ body.dark-mode .leaderboard-updated {
     width: 200px;
     height: 35px;
     padding: 0 1rem;
-
-    border: 2px solid var(--brand-color-primary);
+    border: 2px solid #00B39F;
     border-radius: 8px;
 
     background: #ffffff;
-    color: var(--brand-color-primary);
+    color: #00B39F;
 
     font-size: 0.80rem;
     font-weight: 600;
@@ -400,7 +397,6 @@ body.dark-mode .period-select {
     ───────────────────────────── */
 
 @media (max-width: 768px) {
-
     .leaderboard-podium {
         gap: 1rem;
     }
@@ -430,7 +426,6 @@ body.dark-mode .period-select {
     ───────────────────────────── */
 
 @media (max-width: 600px) {
-
     .leaderboard-section .leaderboard-controls {
         flex-wrap: nowrap;
         justify-content: center;

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -26,9 +26,8 @@
     width: 320px;
     max-width: 90%;
     padding: 0.9rem 1.4rem;
-    border: 2px solid #00B39F;
+    border: 2px solid #000000;
     border-radius: 8px;
-
     font-size: 1rem;
     font-weight: 500;
 
@@ -364,12 +363,10 @@ body.dark-mode .leaderboard-updated {
     width: 200px;
     height: 35px;
     padding: 0 1rem;
-    border: 2px solid #00B39F;
+    border: 2px solid #000000;
     border-radius: 8px;
-
     background: #ffffff;
-    color: #00B39F;
-
+    color: #000000;
     font-size: 0.80rem;
     font-weight: 600;
 

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -326,7 +326,7 @@ body.dark-mode .podium-score {
 }
 
 .leaderboard-table tbody tr:nth-child(even) {
-    background-color: #00D3A9;
+    background-color: var(--brand-color-primary);
 }
 
 body.dark-mode {
@@ -399,9 +399,6 @@ body.dark-mode .leaderboard-updated {
 
 .period-select:focus-visible {
     box-shadow: 0 0 0 3px var(--color-secondary-dark);
-}
-body.dark-mode .period-select:focus-visible {
-    box-shadow: 0 0 0 3px var(--brand-color-primary);
 }
 
 body.dark-mode .period-select {

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -26,7 +26,7 @@
     width: 320px;
     max-width: 90%;
     padding: 0.9rem 1.4rem;
-    border: 2px solid #000000;
+    border: 2px solid var(--brand-color-primary);
     border-radius: 8px;
     font-size: 1rem;
     font-weight: 500;
@@ -53,6 +53,7 @@
 body.dark-mode .leaderboard-filter {
     background: #000000;
     color: #ffffff;
+    border-color: var(--color-secondary-dark);
 }
 
 body.dark-mode .leaderboard-filter::placeholder {
@@ -214,7 +215,7 @@ body.dark-mode .leaderboard-filter::placeholder {
 }
 
 .podium-username-link:hover .podium-username {
-    color: var(--brand-color-primary);
+    color: var(--color-secondary-dark);
 }
 
 .podium-username {
@@ -222,10 +223,18 @@ body.dark-mode .leaderboard-filter::placeholder {
     font-weight: 700;
     line-height: 1.1;
     text-align: center;
-    color: var(--brand-color-primary);
+    color: var(--color-secondary-dark);
     transition: color 0.2s ease;
     width: 100%;
     overflow-wrap: break-word;
+}
+
+body.dark-mode .podium-username-link:hover .podium-username {
+    color: var(--brand-color-primary);
+}
+
+body.dark-mode .podium-username {
+    color: var(--brand-color-primary);
 }
 
 /* Stats */
@@ -266,8 +275,12 @@ body.dark-mode .podium-stat-value {
 .podium-score {
     font-size: 2rem;
     font-weight: 800;
-    color: var(--brand-color-primary);
+    color: var(--color-secondary-dark);
     line-height: 1;
+}
+
+body.dark-mode .podium-score {
+    color: var(--brand-color-primary);
 }
 
 /* ─────────────────────────────
@@ -363,10 +376,10 @@ body.dark-mode .leaderboard-updated {
     width: 200px;
     height: 35px;
     padding: 0 1rem;
-    border: 2px solid #000000;
+    border: 2px solid var(--brand-color-primary);
     border-radius: 8px;
     background: #ffffff;
-    color: #000000;
+    color: var(--color-secondary-dark);
     font-size: 0.80rem;
     font-weight: 600;
 
@@ -387,6 +400,7 @@ body.dark-mode .leaderboard-updated {
 body.dark-mode .period-select {
     background: #000000;
     color: #ffffff;
+    border-color: var(--color-secondary-dark);
 }
 
 /* ─────────────────────────────

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -46,7 +46,7 @@
 }
 
 .leaderboard-filter:focus-visible {
-    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
+    box-shadow: 0 0 0 3px var(--color-secondary-dark);
 }
 
 /* Dark mode */
@@ -58,6 +58,10 @@ body.dark-mode .leaderboard-filter {
 
 body.dark-mode .leaderboard-filter::placeholder {
     color: #ffffff;
+}
+
+body.dark-mode .leaderboard-filter:focus-visible {
+    box-shadow: 0 0 0 3px var(--brand-color-primary);
 }
 
 /* ─────────────────────────────
@@ -394,13 +398,20 @@ body.dark-mode .leaderboard-updated {
 }
 
 .period-select:focus-visible {
-    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
+    box-shadow: 0 0 0 3px var(--color-secondary-dark);
+}
+body.dark-mode .period-select:focus-visible {
+    box-shadow: 0 0 0 3px var(--brand-color-primary);
 }
 
 body.dark-mode .period-select {
     background: #000000;
     color: #ffffff;
     border-color: var(--color-secondary-dark);
+}
+
+body.dark-mode .period-select:focus-visible {
+    box-shadow: 0 0 0 3px var(--brand-color-primary);
 }
 
 /* ─────────────────────────────

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -46,14 +46,14 @@
 }
 
 .leaderboard-filter:focus-visible {
-    box-shadow: 0 0 0 3px var(--color-secondary-dark);
+    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
 }
 
 /* Dark mode */
 body.dark-mode .leaderboard-filter {
     background: #000000;
     color: #ffffff;
-    border-color: var(--color-secondary-dark);
+    border-color: var(--brand-color-primary);
 }
 
 body.dark-mode .leaderboard-filter::placeholder {
@@ -61,7 +61,7 @@ body.dark-mode .leaderboard-filter::placeholder {
 }
 
 body.dark-mode .leaderboard-filter:focus-visible {
-    box-shadow: 0 0 0 3px var(--brand-color-primary);
+    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
 }
 
 /* ─────────────────────────────
@@ -219,7 +219,7 @@ body.dark-mode .leaderboard-filter:focus-visible {
 }
 
 .podium-username-link:hover .podium-username {
-    color: var(--color-secondary-dark);
+    color: var(--brand-color-primary);
 }
 
 .podium-username {
@@ -227,7 +227,7 @@ body.dark-mode .leaderboard-filter:focus-visible {
     font-weight: 700;
     line-height: 1.1;
     text-align: center;
-    color: var(--color-secondary-dark);
+    color: var(--brand-color-primary);
     transition: color 0.2s ease;
     width: 100%;
     overflow-wrap: break-word;
@@ -279,7 +279,7 @@ body.dark-mode .podium-stat-value {
 .podium-score {
     font-size: 2rem;
     font-weight: 800;
-    color: var(--color-secondary-dark);
+    color: var(--brand-color-primary);
     line-height: 1;
 }
 
@@ -383,7 +383,7 @@ body.dark-mode .leaderboard-updated {
     border: 2px solid var(--brand-color-primary);
     border-radius: 8px;
     background: #ffffff;
-    color: var(--color-secondary-dark);
+    color: var(--brand-color-primary);
     font-size: 0.80rem;
     font-weight: 600;
 
@@ -398,17 +398,17 @@ body.dark-mode .leaderboard-updated {
 }
 
 .period-select:focus-visible {
-    box-shadow: 0 0 0 3px var(--color-secondary-dark);
+    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
 }
 
 body.dark-mode .period-select {
     background: #000000;
     color: #ffffff;
-    border-color: var(--color-secondary-dark);
+    border-color: var(--brand-color-primary);
 }
 
 body.dark-mode .period-select:focus-visible {
-    box-shadow: 0 0 0 3px var(--brand-color-primary);
+    box-shadow: 0 0 0 3px rgba(0, 211, 169, 0.15);
 }
 
 /* ─────────────────────────────


### PR DESCRIPTION
## Description

Updates the leaderboard UI to consistently use Meshery's Caribbean Green instead of Keppel green.

Fixes #2922

## Changes

- Replaced leaderboard uses of `var(--brand-color-secondary)` with `var(--brand-color-primary)`
- Replaced hardcoded Keppel green `#00B39F` with Meshery's Caribbean Green `var(--brand-color-primary)` (`#00D3A9`)
- Updated the podium username, podium score, and period selector text to use `var(--brand-color-primary)`
- Updated the filter and period selector focus rings to use the original translucent Caribbean Green treatment
- Updated dark-mode filter and period selector borders to use `var(--brand-color-primary)`
- Preserved the existing responsive leaderboard layout across desktop, tablet, and mobile
- Verified the leaderboard UI locally in both light and dark modes

## Screenshots

Before/after screenshots showing the podium username, podium score, and period selector in both light and dark modes.

### Before

#### Light Mode

<img width="1081" height="822" alt="image" src="https://github.com/user-attachments/assets/2506848b-119e-4f31-b793-74b4408993c0" />

#### Dark Mode

![Before - Dark Mode](PASTE_BEFORE_DARK_SCREENSHOT_URL_HERE)
<img width="1026" height="811" alt="image" src="https://github.com/user-attachments/assets/d3f22f47-c99b-422d-be27-8448ca645df1" />


### After

#### Light Mode

<img width="1105" height="745" alt="image" src="https://github.com/user-attachments/assets/8d6242e2-5a19-4a2d-b5b5-fc3f54100487" />



#### Dark Mode

<img width="1327" height="819" alt="image" src="https://github.com/user-attachments/assets/1e7d7f1e-72ef-4418-8475-89725d631c3c" />


<img width="1090" height="678" alt="image" src="https://github.com/user-attachments/assets/54bbb573-1ead-4582-9b8c-05438558db81" />

## Summary

- **Accessibility**
  - Added visible keyboard focus indicators for the filter and period selector in both light and dark modes.
  - Preserved the original translucent focus-ring treatment using `rgba(0, 211, 169, 0.15)`.
  - Verified the requested podium username, podium score, and period selector colors in both light and dark modes.

- **Branding**
  - Replaced Keppel green with Meshery's Caribbean Green (`#00D3A9`) for the intended leaderboard accents.
  - Applied `var(--brand-color-primary)` to the podium username, podium score, period selector, table header, alternating rows, and relevant controls.

- **Responsive UI**
  - Preserved the existing leaderboard layout and responsive behavior across desktop, tablet, and mobile.