### PR TITLE
fix(leaderboard): add page title and align content via layout:plain

### DIFF
--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -531,3 +531,9 @@ body.dark-mode .period-select {
         margin: 0 auto;
     }
 }
+
+.leaderboard-container {
+    max-width: 900px;
+    margin: 0 auto;
+    width: 100%;
+}

--- a/leaderboard.md
+++ b/leaderboard.md
@@ -1,12 +1,17 @@
 ---
-layout: page
+layout: plain
 title: Community Leaderboard
 permalink: /community/leaderboard/
 description: "Recognizing the most active members of the Meshery discussion forum."
 redirect_from:
   - /community/leaderboard
 ---
-
+{% include partials/extension-header.html
+    title="Meshery Community Leaderboard"
+    description="Recognizing the most active members of the Meshery discussion forum."
+%}
+<div class="leaderboard-container" markdown="1">
 Celebrating the top contributors on the [Meshery discussion forum](https://discuss.meshery.io) this week. Rankings are based on posts created, likes received, and solutions accepted — switch periods below to see monthly or all-time standings.
 
 {% include leaderboard.html %}
+</div>


### PR DESCRIPTION
Fixes #2928


While looking into this, I found that the missing title wasn't really a "forgot to add a heading" thing it's a small logic gap in _layouts/page.html. Its title block checks {% if page.name %}, but page.name is Jekyll's built-in filename attribute, so it's always truthy. That means the branch only ever fires for pages in the catalog/models/filters collections, and leaderboard.md never qualified. Meanwhile the description paragraph renders unconditionally, which is exactly why the page jumped straight into subtext with nothing identifying it above.

Rather than patch around that in the shared layout (which felt riskier and out of scope here), I switched leaderboard.md to layout: plain the same layout the Models page already uses and reused partials/extension-header.html for the title and subtext. That gets the styling to match Models exactly for free, since it's literally the same component rendering it, not a re-creation of it.

For the alignment issue, I added a .leaderboard-container wrapper (max-width: 900px, centered) around the intro paragraph and the leaderboard include, so the intro text, filter/search row, podium cards, and table all line up on the same left and right edges instead of drifting to different widths. I also added markdown="1" to that div worth calling out specifically, since without it kramdown treats content inside a raw HTML block as plain HTML and won't convert the [Meshery discussion forum](...) markdown link in the intro paragraph into an actual hyperlink. Easy thing to miss, so flagging it here in case it comes up in review.

Files changed

leaderboard.md
_sass/leaderboard.scss



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved leaderboard page layout with a centered content area and a maximum width of 900px.
  * Updated the leaderboard page to use the standard extension-header layout.
  * Enabled Markdown rendering within the leaderboard content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->