### PR TITLE
fix: correct Louie Corbo testimonial typo

### DIFF
--- a/_data/testimonials.yml
+++ b/_data/testimonials.yml
@@ -1,6 +1,6 @@
 - quote: "Meshery is what the next-generation Operations tooling will look like."
   person: Louie Corbo
-  title: Staff Cloud Infratructure Engineer at SADA
+  title: Staff Cloud Infrastructure Engineer at SADA
   image: /assets/images/photos/louie-corbo.jpeg
 
 


### PR DESCRIPTION
## Description

Fixes #2943

Corrects the typo in Louie Corbo's job title on the Meshery homepage.

### Change

- Changed `Infratructure` to `Infrastructure`
- No other content was modified.

### Testing

- Verified the change in `_data/testimonials.yml`
- Verified the diff contains only the intended typo correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in the Louie Corbo testimonial title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->