### PR TITLE
fix: correct grammar on integrations page

### DIFF
--- a/integrations/index.html
+++ b/integrations/index.html
@@ -173,7 +173,7 @@ permalink: /integrations
         Support for your Cloud Native Infrastructure and Apps
       </h2>
       <p style="margin:auto 10vw;">
-      Meshery seamlessly integrates with all CNCF projects, your existing tools, Kubernetes clusters, and multiple Clouds, allowing you to enhance use your preferred monitoring, CI/CD, and security solutions. 
+      Meshery seamlessly integrates with all CNCF projects, your existing tools, Kubernetes clusters, and multiple Clouds, allowing you to use your preferred monitoring, CI/CD, and security solutions.
     </p><p style="margin:2vw 10vw 0vw 10vw;">
       Experience collaborative infrastructure management. Try any of these integrations in Meshery's <a href="https://play.meshery.io">playground</a>.
       </p>


### PR DESCRIPTION
## Description

Fixes #2945

Corrects a grammar error on the Meshery Integrations page.

### Change

- Changed "allowing you to enhance use your preferred..." to "allowing you to use your preferred..."

This is a documentation/content-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the integrations page description for clearer, more concise wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->