### PR TITLE
fix: correct AWS Application Autoscaling typo

### DIFF
--- a/collections/_models/aws-applicationautoscaling-controller/aws-applicationautoscaling-controller.md
+++ b/collections/_models/aws-applicationautoscaling-controller/aws-applicationautoscaling-controller.md
@@ -1,8 +1,8 @@
 ---
 layout: single-page-model
 item-type: model
-name: AWS Applilcation Autoscaling
-subtitle: Collaborative and visual infrastructure as design for AWS Applilcation Autoscaling
+name: AWS Application Autoscaling
+subtitle: Collaborative and visual infrastructure as design for AWS Application Autoscaling
 colorIcon: /assets/images/integration/aws-applicationautoscaling-controller/icons/color/aws-applicationautoscaling-controller-color.svg
 whiteIcon: /assets/images/integration/aws-applicationautoscaling-controller/icons/white/aws-applicationautoscaling-controller-white.svg
 docURL: https://docs.meshery.io/extensibility/integrations/aws-applicationautoscaling-controller


### PR DESCRIPTION
## Summary

- Corrected the misspelling of "Application" in the AWS Application Autoscaling model name.
- Corrected the same typo in the model subtitle.
- No other model metadata or paths were changed.

Fixes #2948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the spelling of “Application” in the AWS Application Autoscaling integration’s displayed name and subtitle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->