### PR TITLE
fix: remove duplicate closing h3 tag

### DIFF
--- a/_includes/popular-discuss-posts.html
+++ b/_includes/popular-discuss-posts.html
@@ -1,4 +1,4 @@
-<h3>Most popular Discussions with "{{ include.tag }}" Tag</h3></h3>
+<h3>Most popular Discussions with "{{ include.tag }}" Tag</h3>
 <ul id="posts">
    <!-- -->
   {% assign item = site.data.discuss.meshery -%}


### PR DESCRIPTION
## Summary

- Removed the duplicate closing `</h3>` tag from the Most popular Discussions heading.
- This fixes the malformed HTML in the popular discussions template.
- No other template behavior was changed.

Fixes #2955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the heading markup for popular discussions to ensure it renders properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->