### PR TITLE
fix: remove duplicate meta description

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,9 +4,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="test" content="testing" />
     <!-- Google Tag Manager -->
+    {% if page.patternInfo %}
     <meta name="description" content="{{ page.patternInfo | url_decode }}" />
+    {% endif %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
## Description

Fixes #2964

This PR removes the leftover test meta tag from `_includes/header.html` and conditionally renders the `patternInfo` meta description only when `page.patternInfo` exists.

### Changes

-Removed the <meta name="test" content="testing" /> tag.
-Wrapped the patternInfo meta description in a {% if page.patternInfo %} condition.
-The condition ensures that the metadata is only rendered when page.patternInfo is available, preventing empty meta description tags on pages without pattern information.
-This also helps avoid duplicate or unnecessary meta description tags

### Why the conditional is needed

-page.patternInfo is not available on every page. Keeping the meta description inside the if condition ensures that it is generated only for pages that have the required pattern information, rather than producing an empty metadata tag on other pages.


### Testing

- Verified the changes using `git diff`.
- Confirmed that only `_includes/header.html` was modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed an unintended test metadata tag from generated pages.
  - Description metadata is now included only when pattern information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->