### PR TITLE
Add mesheryctl-axi to the extensions catalog

### DIFF
--- a/collections/_extensions/mesheryctl-axi.md
+++ b/collections/_extensions/mesheryctl-axi.md
@@ -1,0 +1,30 @@
+---
+layout: single-page-extension
+item-type: extension
+name: mesheryctl-axi
+kind: Plugin
+userName: Meshery Authors
+type: Configuration
+compatibility: 
+  - meshery
+  - kubernetes
+logo: /assets/images/logos/meshery-logo-light.svg
+whiteImage: /assets/images/logos/meshery-logo-light.svg
+colorImage: /assets/images/logos/meshery-logo-light.svg
+image-light: /assets/images/logos/meshery-logo-light.svg
+extensionInfo: |
+  mesheryctl-axi is an agent-ergonomic <a href="https://axi.md/">AXI</a> wrapper around <a href="https://docs.meshery.io/reference/mesheryctl">mesheryctl</a>. It wraps the human-facing CLI rather than changing it, presenting the same Meshery operations through an interface designed for AI agents and automation: token-efficient TOON output for list and view reporting, definitive empty states, structured errors, and <code>help[]</code> next-step suggestions on every successful command.
+
+  Run it with <code>npx -y mesheryctl-axi</code>. It spawns your existing mesheryctl binary, so mesheryctl must be installed and authenticated; Meshery itself is not embedded in the package. Schema-faithful content retrieval for designs and models is always returned as raw YAML or JSON, never as TOON, so what you read back is exactly what Meshery stores.
+
+extensionCaveats: |
+  - Token-Efficient Output: TOON rendering of list and view results keeps agent context windows small compared to raw CLI tables or verbose JSON.
+  - Always Non-Interactive: Every command runs without TTY prompts, so agent workflows never stall waiting on input.
+  - Structured Errors and Next Steps: Unknown flags and failures exit non-zero with a structured TOON error, and successes carry help[] suggestions that guide the next command.
+  - Zero-Install Usage: Invoke directly with npx -y mesheryctl-axi against your existing, authenticated mesheryctl installation.
+
+URL: https://github.com/meshery-extensions/mesheryctl-axi
+docsURL: https://docs.meshery.io/extensions/extensions/
+---
+
+{{ page.extensionCaveats }}


### PR DESCRIPTION
## Description

Adds `collections/_extensions/mesheryctl-axi.md` so [`mesheryctl-axi`](https://github.com/meshery-extensions/mesheryctl-axi) is listed in the extensions catalog published at https://meshery.io/extensions.

`mesheryctl-axi` is an agent-ergonomic [AXI](https://axi.md/) wrapper around [`mesheryctl`](https://docs.meshery.io/reference/mesheryctl): token-efficient TOON output for list/view reporting, definitive empty states, structured errors, `help[]` next-step suggestions, and always-non-interactive execution. Run it with `npx -y mesheryctl-axi`; it spawns your existing authenticated `mesheryctl` binary rather than embedding Meshery.

This PR fixes #2969
Refs meshery/meshery#20979

## Taxonomy and asset choices

Rather than inventing values, the entry matches what the collection already uses:

- **`type: Configuration`** - the grouping chip on `collections/_pages/extensions.html`. This is the value the other CLI plugin entries use (`kubectl-meshsync-snapshot`, `kubectl-kanvas-snapshot`, `helm-kanvas-snapshot`), so `mesheryctl-axi` lands with the rest of the CLI tooling.
- **`kind: Plugin`** - already in use by `kanvas.md` and `shape-builder.md`, and accurate here: this wraps the CLI, it is not a GitOps snapshot tool.
- **Logo fields** reuse `/assets/images/logos/meshery-logo-light.svg`, an existing asset already referenced as `colorImage` by `meshery-design-embed.md`. No new asset is introduced; a bespoke `mesheryctl-axi` mark can replace it later without touching anything else.
- **`docsURL`** points at https://docs.meshery.io/extensions/extensions/ until a dedicated `mesheryctl-axi` docs page exists.

## Verification

- Frontmatter parses as valid YAML (checked with `YAML.safe_load` over the frontmatter block); all four referenced logo paths resolve to files that exist in the repo.
- Field shape diffed against `kubectl-meshsync-snapshot.md` and the other CLI plugin entries - same keys, same ordering, same `extensionInfo` / `extensionCaveats` block-scalar style, same trailing `{{ page.extensionCaveats }}` body.
- A full local Jekyll build was **not** run: this checkout's Ruby is 2.6.10 and the `Gemfile` requires >= 3.2.2, with no newer Ruby available on the machine. The `build-pr-preview` workflow performs the real build on this PR - please confirm the preview renders the new card under the Configuration group before merging.

## Notes for Reviewers

Change is scoped to the single new listing file; nothing else is touched.

## Signed commits

- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added metadata and descriptive information for the Meshery CLI Axi extension.
  - Documented compatibility requirements, usage prerequisites, supported features, known caveats, and links to the extension’s repository and documentation.
  - Added branding assets and rendered caveat content to improve the extension’s presentation and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->