### PR TITLE
fix: remove versioned catalog artifacts on deletion

### DIFF
--- a/.github/workflows/delete-catalog.yml
+++ b/.github/workflows/delete-catalog.yml
@@ -26,7 +26,7 @@ jobs:
           fi
           filename="${{ github.event.client_payload.pattern_id }}"
           if [[ $filename != "" ]]; then
-            rm -f $MESHERY_CATALOG_FILES_DIR/$filename.yaml
+            rm -rf "$MESHERY_CATALOG_FILES_DIR/$filename"
             rm -f ./collections/_catalog/"$(echo $patternType | tr '[:upper:]' '[:lower:]')"/$filename.md
           else
             echo "No patterns to delete"
@@ -40,7 +40,7 @@ jobs:
           fi
           filename="${{ github.event.client_payload.filter_id }}"
           if [[ $filename != "" ]]; then
-            rm -f $MESHERY_CATALOG_FILES_DIR/$filename.yaml
+            rm -rf "$MESHERY_CATALOG_FILES_DIR/$filename"
             rm -f ./collections/_catalog/"$(echo $filterType | tr '[:upper:]' '[:lower:]')"/$filename.md
           else
             echo "No Filters to delete"


### PR DESCRIPTION
## Description

Fixes #2976.

The catalog deletion workflow was attempting to remove the obsolete
`catalog/<pattern-id>.yaml` structure, while the current catalog generator
stores artifacts under:

```text
catalog/<pattern-id>/<version>/
├── design.yml
└── artifacthub-pkg.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog cleanup to reliably remove catalog pattern and filter directories during deletion.
  * Added safer path handling for cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->